### PR TITLE
Fix Cloud Deploy authentication issue

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -57,6 +57,8 @@ jobs:
     
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
+      with:
+        project_id: ${{ env.PROJECT_ID }}
     
     - name: Create audit log entry
       run: |
@@ -73,7 +75,7 @@ jobs:
             \"change_type\": \"application_deployment\"
           }" \
           --severity=INFO \
-          --project=$PROJECT_ID
+          --project=${{ env.PROJECT_ID }}
     
     - name: Deploy to non-production
       id: deploy


### PR DESCRIPTION
## Summary
Fixes the deployment pipeline failing with authentication error.

## Changes
- Set project ID explicitly in gcloud setup step
- Use proper env variable syntax in gcloud logging command

## Error Fixed
The CD pipeline was failing with:
```
ERROR: (gcloud.logging.write) You do not currently have an active account selected.
Process completed with exit code 1.
```

This ensures gcloud is properly configured before running commands.