### PR TITLE
fix: correct Cloud Deploy pipeline name

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -30,7 +30,7 @@ on:
 env:
   PROJECT_ID: u2i-tenant-webapp
   REGION: europe-west1
-  PIPELINE: webapp-delivery-pipeline
+  PIPELINE: webapp-pipeline
 
 jobs:
   deploy-nonprod:

--- a/.github/workflows/production-promotion.yml
+++ b/.github/workflows/production-promotion.yml
@@ -20,7 +20,7 @@ on:
 env:
   PROJECT_ID: u2i-tenant-webapp
   REGION: europe-west1
-  PIPELINE: webapp-delivery-pipeline
+  PIPELINE: webapp-pipeline
 
 jobs:
   validate-approval:


### PR DESCRIPTION
## Summary
- Fixed pipeline name from 'webapp-delivery-pipeline' to 'webapp-pipeline' in both deployment workflows
- This matches the actual pipeline created in our infrastructure

## Test plan
- [ ] Verify workflows can now successfully create Cloud Deploy releases
- [ ] Check that the service account has proper permissions

🤖 Generated with [Claude Code](https://claude.ai/code)