### PR TITLE
fix: specify GCS staging directory for Cloud Deploy

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -90,6 +90,7 @@ jobs:
           --region=$REGION \
           --delivery-pipeline=$PIPELINE \
           --source=. \
+          --gcs-source-staging-dir=gs://u2i-tenant-webapp-deploy-artifacts/source \
           --labels="environment=non-production,compliance=iso27001-soc2-gdpr,deployed-by=github-actions"
         
         echo "✅ Created release: $RELEASE_NAME"


### PR DESCRIPTION
## Summary
- Added --gcs-source-staging-dir flag to gcloud deploy releases create command
- This prevents Cloud Deploy from trying to create a new bucket and uses our existing deployment artifacts bucket instead

## Test plan
- [ ] Verify deployment workflow can create releases without storage.buckets.create permission
- [ ] Check that releases are staged in the correct bucket

🤖 Generated with [Claude Code](https://claude.ai/code)