### PR TITLE
Fix image registry configuration for Cloud Deploy

### DIFF
--- a/k8s-manifests/deployment.yaml
+++ b/k8s-manifests/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: webapp
-        image: europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images/webapp:v1.0.0
+        image: europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images/webapp
         ports:
         - containerPort: 8080
           name: http

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,7 +4,7 @@ metadata:
   name: webapp-deployment
 build:
   artifacts:
-  - image: webapp
+  - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images/webapp
     docker:
       dockerfile: Dockerfile
 manifests:


### PR DESCRIPTION
## Summary
- Fixed skaffold.yaml to use full artifact registry path
- Removed hardcoded tag from deployment.yaml

## Problem
Cloud Deploy render was failing because skaffold didn't know which registry to push images to.

## Solution
- Updated skaffold.yaml to use the full artifact registry path: 
- Removed the hardcoded  tag from deployment.yaml to allow Cloud Deploy to manage tags dynamically

This should fix the render failures we've been experiencing.