### PR TITLE
fix: add ingress host patches for each environment

### DIFF
--- a/k8s/overlays/nonprod/ingress-patch.yaml
+++ b/k8s/overlays/nonprod/ingress-patch.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: webapp-ingress
+  namespace: webapp-team
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "webapp.u2i.dev"
+spec:
+  rules:
+  - host: webapp.u2i.dev
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: webapp-service
+            port:
+              number: 80
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: webapp-ssl-cert
+  namespace: webapp-team
+spec:
+  domains:
+  - webapp.u2i.dev

--- a/k8s/overlays/nonprod/kustomization.yaml
+++ b/k8s/overlays/nonprod/kustomization.yaml
@@ -13,3 +13,11 @@ patches:
   target:
     kind: Deployment
     name: webapp
+- path: ingress-patch.yaml
+  target:
+    kind: Ingress
+    name: webapp-ingress
+- path: ingress-patch.yaml
+  target:
+    kind: ManagedCertificate
+    name: webapp-ssl-cert

--- a/k8s/overlays/prod/ingress-patch.yaml
+++ b/k8s/overlays/prod/ingress-patch.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: webapp-ingress
+  namespace: webapp-team
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "webapp.u2i.com"
+spec:
+  rules:
+  - host: webapp.u2i.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: webapp-service
+            port:
+              number: 80
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: webapp-ssl-cert
+  namespace: webapp-team
+spec:
+  domains:
+  - webapp.u2i.com

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -13,3 +13,11 @@ patches:
   target:
     kind: Deployment
     name: webapp
+- path: ingress-patch.yaml
+  target:
+    kind: Ingress
+    name: webapp-ingress
+- path: ingress-patch.yaml
+  target:
+    kind: ManagedCertificate
+    name: webapp-ssl-cert


### PR DESCRIPTION
## Summary
- Fixes deployment error caused by unresolved placeholders in ingress configuration
- Adds environment-specific patches for ingress host values

## Changes
- Created ingress-patch.yaml for both nonprod and prod overlays
- Patches replace  placeholders with actual hostnames:
  - nonprod: webapp.u2i.dev
  - prod: webapp.u2i.com
- Updates kustomization.yaml to apply the patches

This fixes the error: 'Ingress.networking.k8s.io "webapp-ingress" is invalid: spec.rules[0].host: Invalid value: "${INGRESS_HOST}"'

🤖 Generated with [Claude Code](https://claude.ai/code)