### PR TITLE
fix: split ingress and managed certificate patches

### DIFF
--- a/k8s/overlays/nonprod/ingress-patch.yaml
+++ b/k8s/overlays/nonprod/ingress-patch.yaml
@@ -17,12 +17,3 @@ spec:
             name: webapp-service
             port:
               number: 80
----
-apiVersion: networking.gke.io/v1
-kind: ManagedCertificate
-metadata:
-  name: webapp-ssl-cert
-  namespace: webapp-team
-spec:
-  domains:
-  - webapp.u2i.dev

--- a/k8s/overlays/nonprod/kustomization.yaml
+++ b/k8s/overlays/nonprod/kustomization.yaml
@@ -17,7 +17,7 @@ patches:
   target:
     kind: Ingress
     name: webapp-ingress
-- path: ingress-patch.yaml
+- path: managed-cert-patch.yaml
   target:
     kind: ManagedCertificate
     name: webapp-ssl-cert

--- a/k8s/overlays/nonprod/managed-cert-patch.yaml
+++ b/k8s/overlays/nonprod/managed-cert-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: webapp-ssl-cert
+  namespace: webapp-team
+spec:
+  domains:
+  - webapp.u2i.dev

--- a/k8s/overlays/prod/ingress-patch.yaml
+++ b/k8s/overlays/prod/ingress-patch.yaml
@@ -17,12 +17,3 @@ spec:
             name: webapp-service
             port:
               number: 80
----
-apiVersion: networking.gke.io/v1
-kind: ManagedCertificate
-metadata:
-  name: webapp-ssl-cert
-  namespace: webapp-team
-spec:
-  domains:
-  - webapp.u2i.com

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -17,7 +17,7 @@ patches:
   target:
     kind: Ingress
     name: webapp-ingress
-- path: ingress-patch.yaml
+- path: managed-cert-patch.yaml
   target:
     kind: ManagedCertificate
     name: webapp-ssl-cert

--- a/k8s/overlays/prod/managed-cert-patch.yaml
+++ b/k8s/overlays/prod/managed-cert-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: webapp-ssl-cert
+  namespace: webapp-team
+spec:
+  domains:
+  - webapp.u2i.com


### PR DESCRIPTION
## Summary
Fixes kustomize error preventing Cloud Deploy renders by splitting patch files.

## Error
```
Multiple Strategic-Merge Patches in one patches entry is not allowed to set patches.target field
```

## Solution
Split the combined ingress-patch.yaml into two separate files:
- **ingress-patch.yaml** - patches only the Ingress resource
- **managed-cert-patch.yaml** - patches only the ManagedCertificate resource

This is required because Kustomize doesn't allow multiple resources in one patch file when using target selectors.

🤖 Generated with [Claude Code](https://claude.ai/code)