### PR TITLE
fix: specify container image tag in deployment

### DIFF
--- a/k8s/overlays/nonprod/deployment-patch.yaml
+++ b/k8s/overlays/nonprod/deployment-patch.yaml
@@ -9,6 +9,7 @@ spec:
     spec:
       containers:
       - name: webapp
+        image: europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images/webapp:v1.0.0
         env:
         - name: ENVIRONMENT
           value: "nonprod"


### PR DESCRIPTION
## Summary
Fixes deployment error where Cloud Deploy couldn't pull the container image.

## Error
```
container webapp is waiting to start: europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images/webapp can't be pulled
```

## Solution
- Added explicit image tag (v1.0.0) to the deployment patch
- This uses the existing image that was built 3 days ago
- Deployment should now succeed as all other issues (RBAC, ingress) have been resolved

## Next Steps
In a follow-up PR, we should:
1. Add a proper CI pipeline that builds and tags images on merge
2. Update Cloud Deploy to use the dynamically built images
3. Implement proper versioning strategy

🤖 Generated with [Claude Code](https://claude.ai/code)