### PR TITLE
Update deployment pipeline to use webapp-pipeline-v2

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -30,7 +30,7 @@ on:
 env:
   PROJECT_ID: u2i-tenant-webapp
   REGION: europe-west1
-  PIPELINE: webapp-pipeline
+  PIPELINE: webapp-pipeline-v2
 
 jobs:
   deploy-nonprod:


### PR DESCRIPTION
## Summary
- Switch deployment target from shared GKE cluster to dedicated webapp cluster
- Update pipeline name from `webapp-pipeline` to `webapp-pipeline-v2`

## Rationale
The webapp team now has a dedicated GKE cluster in the webapp project. This change updates the deployment pipeline to target the new cluster, which:
- Simplifies Config Connector setup by avoiding cross-project references
- Provides better isolation for the webapp team
- Allows the team to manage their own cluster-level resources

## Changes
- Updated `PIPELINE` environment variable in `.github/workflows/cd-deploy.yml`

## Testing
The new pipeline has been configured and tested manually. Next deployment will target the webapp cluster.

🤖 Generated with [Claude Code](https://claude.ai/code)