### PR TITLE
Add skaffold.yaml for Cloud Deploy

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,24 @@
+apiVersion: skaffold/v4beta6
+kind: Config
+metadata:
+  name: webapp-deployment
+build:
+  artifacts:
+  - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images/webapp
+    docker:
+      dockerfile: Dockerfile
+manifests:
+  kustomize:
+    paths:
+    - k8s-clean/overlays/nonprod
+profiles:
+- name: non-prod
+  manifests:
+    kustomize:
+      paths:
+      - k8s-clean/overlays/nonprod
+- name: prod
+  manifests:
+    kustomize:
+      paths:
+      - k8s-clean/overlays/prod


### PR DESCRIPTION
Cloud Deploy requires skaffold.yaml to exist. This uses the same k8s-clean structure.