### PR TITLE
Fix Config Connector resources for Autopilot deployment

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -33,6 +33,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
+  location: global
   checkIntervalSec: 10
   timeoutSec: 5
   healthyThreshold: 2
@@ -48,6 +49,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
+  location: global
   protocol: TCP
   loadBalancingScheme: EXTERNAL
   healthChecks:
@@ -78,8 +80,7 @@ spec:
   backendServiceRef:
     name: webapp-dev-backend
   sslCertificates:
-  - sslCertificateRef:
-      name: webapp-dev-cert
+  - name: webapp-dev-cert
   sslPolicyRef:
     name: webapp-ssl-policy
   proxyHeader: NONE
@@ -94,7 +95,7 @@ metadata:
 spec:
   location: global
   portRange: "443"
-  IPProtocol: TCP
+  ipProtocol: TCP
   loadBalancingScheme: EXTERNAL
   target:
     targetSSLProxyRef:


### PR DESCRIPTION
## Summary
- Add location field to ComputeHealthCheck and ComputeBackendService
- Fix IPProtocol to ipProtocol in ComputeForwardingRule  
- Fix SSL certificate reference syntax in ComputeTargetSSLProxy

These fixes are required for Config Connector resources to deploy correctly on Autopilot clusters.

## Test Plan
- [x] Config Connector resources validated locally
- [ ] Deploy to non-prod environment via GitHub Actions
- [ ] Verify load balancer creation
- [ ] Test SSL termination