### PR TITLE
Enable Cloud Build for container images

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,6 +7,9 @@ build:
   - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images/webapp
     docker:
       dockerfile: Dockerfile
+  googleCloudBuild:
+    projectId: u2i-tenant-webapp
+    region: europe-west1
 manifests:
   kustomize:
     paths:


### PR DESCRIPTION
## Summary
- Configure Skaffold to use Google Cloud Build for building container images
- This ensures the webapp image is built during the Cloud Deploy render phase

## Why this is needed
The previous deployments failed because the container image wasn't being built. By adding googleCloudBuild configuration, Skaffold will build and push the image to Artifact Registry before deployment.