### PR TITLE
Fix load balancer configuration with autoneg controller

### DIFF
--- a/docs/load-balancer-fixes.md
+++ b/docs/load-balancer-fixes.md
@@ -1,0 +1,62 @@
+# Load Balancer Configuration Fixes
+
+This document describes the fixes applied to make the L4 TCP proxy load balancer work correctly with the webapp.
+
+## Issues Found and Fixed
+
+### 1. Health Check Port
+**Issue**: The Config Connector health check was configured on port 80, but the pods listen on port 8080.
+
+**Fix**: Updated `k8s-clean/overlays/nonprod/config-connector-resources.yaml`:
+```yaml
+tcpHealthCheck:
+  port: 8080  # Changed from 80
+```
+
+### 2. NEG Attachment to Backend Service
+**Issue**: Network Endpoint Groups (NEGs) created by GKE were not automatically attached to the Config Connector backend service.
+
+**Fix**: Implemented autoneg controller with Workload Identity:
+- Added autoneg controller deployment in Terraform (`autoneg-deploy.tf`)
+- Updated service annotation to use `controller.autoneg.dev/neg`
+- No service account keys required - uses Workload Identity
+
+### 3. Config Connector Project Resolution
+**Issue**: Config Connector was incorrectly using the namespace name as the project ID for some resources.
+
+**Workaround**: All Config Connector resources must include explicit project annotation:
+```yaml
+annotations:
+  cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+```
+
+## Architecture
+
+The load balancer setup now works as follows:
+
+1. **GKE creates NEGs**: The `cloud.google.com/neg` annotation on the Service tells GKE to create zonal NEGs
+2. **Autoneg attaches NEGs**: The `controller.autoneg.dev/neg` annotation tells autoneg which backend service to attach the NEGs to
+3. **Config Connector manages LB**: All other load balancer components (SSL cert, health check, backend service, etc.) are managed by Config Connector
+
+## Manual Steps No Longer Required
+
+With autoneg controller deployed, you no longer need to:
+- Manually attach NEGs to backend services
+- Run any post-deployment scripts
+- Manage NEG lifecycle
+
+## Verification
+
+To verify the setup is working:
+
+```bash
+# Check autoneg controller is running
+kubectl get pods -n autoneg-system
+
+# Check NEGs are attached to backend
+gcloud compute backend-services describe webapp-dev-backend \
+  --global --project=u2i-tenant-webapp
+
+# Test the endpoint
+curl https://dev.webapp.u2i.dev/
+```

--- a/k8s-clean/base/service.yaml
+++ b/k8s-clean/base/service.yaml
@@ -3,8 +3,11 @@ kind: Service
 metadata:
   name: webapp-service
   annotations:
-    # Enable NEG for Config Connector L4 LB
-    cloud.google.com/neg: '{"exposed_ports": {"80": {"name": "webapp-neg"}}}'
+    # Enable NEG creation by GKE
+    cloud.google.com/neg: '{"exposed_ports": {"80": {}}}'
+    # Autoneg controller will attach NEGs to backend service
+    controller.autoneg.dev/neg: |
+      {"backend_services":{"80":[{"name":"webapp-dev-backend","max_connections_per_endpoint":100}]}}
 spec:
   type: ClusterIP
   selector:

--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -39,7 +39,7 @@ spec:
   healthyThreshold: 2
   unhealthyThreshold: 3
   tcpHealthCheck:
-    port: 80
+    port: 8080
 ---
 # Backend Service
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
@@ -56,7 +56,8 @@ spec:
   - healthCheckRef:
       name: webapp-dev-health
   connectionDrainingTimeoutSec: 60
-  # NEG will be automatically attached by GKE
+  # NEG attachment requires autoneg controller or manual attachment
+  # The service annotation anthos.cft.dev/autoneg would handle this automatically
 ---
 # SSL Policy
 apiVersion: compute.cnrm.cloud.google.com/v1beta1


### PR DESCRIPTION
## Summary
- Fix health check port from 80 to 8080 to match pod configuration
- Add autoneg controller annotation to automatically attach NEGs to backend service
- Document the fixes and architecture

## Changes
- Updated `k8s-clean/overlays/nonprod/config-connector-resources.yaml` to use correct health check port
- Added `controller.autoneg.dev/neg` annotation to service for automatic NEG attachment
- Created documentation in `docs/load-balancer-fixes.md`

## Testing
The webapp is now accessible at https://dev.webapp.u2i.dev/

## Related
- Terraform modules updated to v1.29.0 to deploy autoneg controller with Workload Identity
- No service account keys required - everything uses Workload Identity

🤖 Generated with [Claude Code](https://claude.ai/code)