### PR TITLE
fix: Add projectRef back to ComputeManagedSSLCertificate only

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -21,6 +21,8 @@ metadata:
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
+  projectRef:
+    external: u2i-tenant-webapp
   managed:
     domains:
     - dev.webapp.u2i.dev


### PR DESCRIPTION
The ComputeManagedSSLCertificate resource specifically requires projectRef in spec, unlike other Config Connector resources. This is enforced by the CRD validation.

This fixes the deployment error:
- The ComputeManagedSSLCertificate "webapp-dev-cert" is invalid: spec.projectRef: Required value

🤖 Generated with [Claude Code](https://claude.ai/code)