### PR TITLE
fix: Add ComputeSSLCertificate stub for existing managed cert

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -17,7 +17,7 @@ spec:
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeManagedSSLCertificate
 metadata:
-  name: webapp-dev-cert
+  name: webapp-dev-managed-cert
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
@@ -26,6 +26,19 @@ spec:
   managed:
     domains:
     - dev.webapp.u2i.dev
+---
+# Stub ComputeSSLCertificate that imports the existing managed certificate
+# This is needed because ComputeTargetSSLProxy expects ComputeSSLCertificate, not ComputeManagedSSLCertificate
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSSLCertificate
+metadata:
+  name: webapp-dev-cert
+  annotations:
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+spec:
+  resourceID: webapp-dev-cert
+  location: global
+  type: MANAGED
 ---
 # Health Check
 apiVersion: compute.cnrm.cloud.google.com/v1beta1


### PR DESCRIPTION
ComputeTargetSSLProxy expects ComputeSSLCertificate references, not ComputeManagedSSLCertificate.

This creates a stub ComputeSSLCertificate that imports the existing managed certificate, allowing the proxy to properly reference it while keeping KRM dependency tracking.

Also renamed the managed certificate to avoid naming conflicts.

This fixes the deployment error:
- ComputeTargetSSLProxy/webapp-dev-ssl-proxy: reference ComputeSSLCertificate webapp-team/webapp-dev-cert is not found

🤖 Generated with [Claude Code](https://claude.ai/code)