### PR TITLE
fix: Use external selfLink for SSL certificate reference

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -27,18 +27,6 @@ spec:
     domains:
     - dev.webapp.u2i.dev
 ---
-# Stub ComputeSSLCertificate that imports the existing managed certificate
-# This is needed because ComputeTargetSSLProxy expects ComputeSSLCertificate, not ComputeManagedSSLCertificate
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeSSLCertificate
-metadata:
-  name: webapp-dev-cert
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-spec:
-  resourceID: webapp-dev-cert
-  location: global
----
 # Health Check
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeHealthCheck
@@ -95,7 +83,7 @@ spec:
   backendServiceRef:
     name: webapp-dev-backend
   sslCertificates:
-  - name: webapp-dev-cert
+  - external: https://www.googleapis.com/compute/v1/projects/u2i-tenant-webapp/global/sslCertificates/webapp-dev-cert
   sslPolicyRef:
     name: webapp-ssl-policy
   proxyHeader: NONE


### PR DESCRIPTION
ComputeTargetSSLProxy expects either a ComputeSSLCertificate KRM reference or an external selfLink. Since we have a ComputeManagedSSLCertificate (not ComputeSSLCertificate), we use the external selfLink approach.

This fixes the deployment errors:
- reference ComputeSSLCertificate webapp-team/webapp-dev-cert is not found
- ComputeSSLCertificate spec.certificate: Required value
- ComputeSSLCertificate spec.privateKey: Required value

🤖 Generated with [Claude Code](https://claude.ai/code)