### PR TITLE
feat: Implement clean GitOps-managed SSL certificates

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -13,11 +13,11 @@ spec:
   addressType: EXTERNAL
   description: "Static IP for webapp dev environment"
 ---
-# SSL Certificate for dev.webapp.u2i.dev
+# Managed SSL Certificate for dev.webapp.u2i.dev (GitOps controlled)
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeManagedSSLCertificate
 metadata:
-  name: webapp-dev-managed-cert
+  name: webapp-dev-cert-v2
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
@@ -26,6 +26,20 @@ spec:
   managed:
     domains:
     - dev.webapp.u2i.dev
+---
+# ComputeSSLCertificate stub for ComputeTargetSSLProxy reference
+# This references the managed certificate created above
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSSLCertificate
+metadata:
+  name: webapp-dev-cert-v2-stub
+  annotations:
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+    # Import the certificate created by ComputeManagedSSLCertificate
+    cnrm.cloud.google.com/state-into-spec: merge
+spec:
+  resourceID: webapp-dev-cert-v2
+  location: global
 ---
 # Health Check
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
@@ -83,7 +97,7 @@ spec:
   backendServiceRef:
     name: webapp-dev-backend
   sslCertificates:
-  - external: https://www.googleapis.com/compute/v1/projects/u2i-tenant-webapp/global/sslCertificates/webapp-dev-cert
+  - name: webapp-dev-cert-v2-stub
   sslPolicyRef:
     name: webapp-ssl-policy
   proxyHeader: NONE


### PR DESCRIPTION
This PR implements a clean slate approach for SSL certificate management, providing full GitOps control.

## Changes
- Create new  named 
- Add  stub  that imports the managed certificate
- Update  to reference the new certificate stub

## Benefits
- Full GitOps control over certificate lifecycle
- Certificate domains managed in code
- Automatic renewal handled by Google
- Clean separation from manually created resources
- Proper Config Connector dependency tracking

## Migration Plan
1. Deploy these new resources
2. Wait for new certificate to become ACTIVE (can take up to 60 minutes)
3. Monitor that traffic switches to new certificate
4. Delete old manual certificates:
   -  (manual)
   -  (unused)

🤖 Generated with [Claude Code](https://claude.ai/code)