### PR TITLE
fix: Use proper GitOps reference for managed SSL certificate

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -27,20 +27,6 @@ spec:
     domains:
     - dev.webapp.u2i.dev
 ---
-# ComputeSSLCertificate stub for ComputeTargetSSLProxy reference
-# This references the managed certificate created above
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeSSLCertificate
-metadata:
-  name: webapp-dev-cert-v2-stub
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-    # Import the certificate created by ComputeManagedSSLCertificate
-    cnrm.cloud.google.com/state-into-spec: merge
-spec:
-  resourceID: webapp-dev-cert-v2
-  location: global
----
 # Health Check
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeHealthCheck
@@ -97,7 +83,7 @@ spec:
   backendServiceRef:
     name: webapp-dev-backend
   sslCertificates:
-  - name: webapp-dev-cert-v2-stub
+  - external: https://www.googleapis.com/compute/v1/projects/u2i-tenant-webapp/global/sslCertificates/webapp-dev-cert-v2
   sslPolicyRef:
     name: webapp-ssl-policy
   proxyHeader: NONE

--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -83,7 +83,8 @@ spec:
   backendServiceRef:
     name: webapp-dev-backend
   sslCertificates:
-  - external: https://www.googleapis.com/compute/v1/projects/u2i-tenant-webapp/global/sslCertificates/webapp-dev-cert-v2
+  - name: webapp-dev-cert-v2
+    kind: ComputeManagedSSLCertificate
   sslPolicyRef:
     name: webapp-ssl-policy
   proxyHeader: NONE


### PR DESCRIPTION
This PR completes the clean slate SSL certificate implementation with proper GitOps control.

## Changes
- Remove invalid ComputeSSLCertificate stub (only for self-managed certs)
- Use direct KRM reference with 
- This enables proper Config Connector dependency tracking and drift detection

## Benefits
- ✅ Full GitOps control - certificate lifecycle managed in code
- ✅ Automatic dependency management - Config Connector waits for ACTIVE status
- ✅ Drift detection - changes outside Git are detected
- ✅ Clean deletion cascade when removed from YAML

## Note
This will cause brief downtime (~5-15 min) while the new certificate provisions. This is acceptable for non-prod.

Once deployed, the old manual certificates can be deleted:
- `webapp-dev-cert` (manual)
- `webapp-dev-managed-cert` (unused)

🤖 Generated with [Claude Code](https://claude.ai/code)