### PR TITLE
feat: Implement Certificate Manager for proper GitOps SSL management

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -13,11 +13,12 @@ spec:
   addressType: EXTERNAL
   description: "Static IP for webapp dev environment"
 ---
-# Managed SSL Certificate for dev.webapp.u2i.dev (GitOps controlled)
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeManagedSSLCertificate
+# Certificate Manager - Modern approach for SSL certificates with full GitOps control
+# 1. Google-managed certificate
+apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+kind: CertificateManagerCertificate
 metadata:
-  name: webapp-dev-cert-v2
+  name: webapp-dev-cert
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
@@ -26,6 +27,49 @@ spec:
   managed:
     domains:
     - dev.webapp.u2i.dev
+    dnsAuthorizations:
+    - name: webapp-dev-auth
+---
+# 2. DNS-01 authorization for the domain
+apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+kind: CertificateManagerDNSAuthorization
+metadata:
+  name: webapp-dev-auth
+  annotations:
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+spec:
+  projectRef:
+    external: u2i-tenant-webapp
+  domain: dev.webapp.u2i.dev
+---
+# 3. Certificate map to group certificates
+apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+kind: CertificateManagerCertificateMap
+metadata:
+  name: webapp-cert-map
+  annotations:
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+spec:
+  projectRef:
+    external: u2i-tenant-webapp
+---
+# 4. Map entry to bind hostname to certificate
+apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+kind: CertificateManagerCertificateMapEntry
+metadata:
+  name: webapp-dev-entry
+  annotations:
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+spec:
+  projectRef:
+    external: u2i-tenant-webapp
+  certificateMapRef:
+    name: webapp-cert-map
+  certificates:
+  - certificateRef:
+      name: webapp-dev-cert
+  matcher: PRIMARY
+  hostname: dev.webapp.u2i.dev
 ---
 # Health Check
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
@@ -82,9 +126,8 @@ metadata:
 spec:
   backendServiceRef:
     name: webapp-dev-backend
-  sslCertificates:
-  - name: webapp-dev-cert-v2
-    kind: ComputeManagedSSLCertificate
+  certificateMapRef:
+    name: webapp-cert-map
   sslPolicyRef:
     name: webapp-ssl-policy
   proxyHeader: NONE


### PR DESCRIPTION
This PR migrates from classic SSL certificates to Certificate Manager, providing full GitOps control with proper dependency tracking.

## What's Changed
- Replace ComputeManagedSSLCertificate with Certificate Manager resources
- Update ComputeTargetSSLProxy to use certificateMapRef instead of sslCertificates

## Benefits
- ✅ **Full dependency tracking** - Config Connector properly manages dependencies
- ✅ **No external URLs** - Everything uses clean KRM references
- ✅ **Automatic provisioning** - Certificates are provisioned via DNS-01 challenge
- ✅ **Future-proof** - Supports multiple certs, wildcard domains, mTLS, etc.
- ✅ **Zero-downtime rotation** - Certificate updates don't affect the proxy

## Components Created
1. **CertificateManagerCertificate** - The managed certificate for dev.webapp.u2i.dev
2. **CertificateManagerDNSAuthorization** - DNS-01 challenge authorization
3. **CertificateManagerCertificateMap** - Groups certificates together
4. **CertificateManagerCertificateMapEntry** - Maps hostname to certificate

## Migration Notes
- Brief downtime expected while new certificate provisions (~5-15 minutes)
- DNS authorization requires a TXT record to be created (handled automatically by Config Connector)
- Old certificates can be deleted after migration is complete:
  - `webapp-dev-cert` (manual)
  - `webapp-dev-managed-cert` (unused)
  - `webapp-dev-cert-v2` (being replaced)

## Verification
After deployment:
```bash
# Check certificate status
kubectl get certificatemanagercertificate webapp-dev-cert -n webapp-team

# Check DNS authorization
kubectl get certificatemanagerdnsauthorization webapp-dev-auth -n webapp-team

# Verify certificate map
kubectl get certificatemanagercertificatemap webapp-cert-map -n webapp-team
```

🤖 Generated with [Claude Code](https://claude.ai/code)