### PR TITLE
fix: Correct Certificate Manager field names

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -27,7 +27,7 @@ spec:
   managed:
     domains:
     - dev.webapp.u2i.dev
-    dnsAuthorizations:
+    dnsAuthorizationsRefs:
     - name: webapp-dev-auth
 ---
 # 2. DNS-01 authorization for the domain
@@ -63,12 +63,10 @@ metadata:
 spec:
   projectRef:
     external: u2i-tenant-webapp
-  certificateMapRef:
+  mapRef:
     name: webapp-cert-map
-  certificates:
-  - certificateRef:
-      name: webapp-dev-cert
-  matcher: PRIMARY
+  certificatesRefs:
+  - name: webapp-dev-cert
   hostname: dev.webapp.u2i.dev
 ---
 # Health Check


### PR DESCRIPTION
Fix Certificate Manager CRD field names based on the actual schema.

## Fixes
- Use `dnsAuthorizationsRefs` (plural) instead of `dnsAuthorizations`
- Use `mapRef` instead of `certificateMapRef`
- Use `certificatesRefs` (plural) instead of `certificates`
- Remove invalid `matcher` field from CertificateMapEntry

These field names match the actual Config Connector CRD schema for Certificate Manager resources.

🤖 Generated with [Claude Code](https://claude.ai/code)