### PR TITLE
Fix ComputeTargetSSLProxy certificateMapRef to use full external reference

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -126,7 +126,7 @@ spec:
   backendServiceRef:
     name: webapp-dev-backend
   certificateMapRef:
-    name: webapp-cert-map
+    external: projects/u2i-tenant-webapp/locations/global/certificateMaps/webapp-cert-map
   sslPolicyRef:
     name: webapp-ssl-policy
   proxyHeader: NONE


### PR DESCRIPTION
## Summary
- Fix certificateMapRef in ComputeTargetSSLProxy to use full external reference format
- This resolves the "not a valid reference" error when updating the SSL proxy

## Changes
- Updated `certificateMapRef` from `name: webapp-cert-map` to `external: projects/u2i-tenant-webapp/locations/global/certificateMaps/webapp-cert-map`

This will allow the SSL proxy to properly use the Certificate Manager certificate map.

🤖 Generated with [Claude Code](https://claude.ai/code)