### PR TITLE
Fix certificateMapRef URI format

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -126,7 +126,7 @@ spec:
   backendServiceRef:
     name: webapp-dev-backend
   certificateMapRef:
-    external: projects/u2i-tenant-webapp/locations/global/certificateMaps/webapp-cert-map
+    external: //certificatemanager.googleapis.com/projects/u2i-tenant-webapp/locations/global/certificateMaps/webapp-cert-map
   sslPolicyRef:
     name: webapp-ssl-policy
   proxyHeader: NONE


### PR DESCRIPTION
Adds the required //certificatemanager.googleapis.com/ prefix