### PR TITLE
Fix External DNS setup for ClusterIP service

### DIFF
--- a/k8s-clean/overlays/nonprod/kustomization.yaml
+++ b/k8s-clean/overlays/nonprod/kustomization.yaml
@@ -28,6 +28,9 @@ patches:
     - op: add
       path: /metadata/annotations/external-dns.alpha.kubernetes.io~1ttl
       value: "300"
+    - op: add
+      path: /metadata/annotations/external-dns.alpha.kubernetes.io~1target
+      value: "34.98.112.208"
 
 configMapGenerator:
 - name: webapp-config


### PR DESCRIPTION
## Summary
- Add External DNS target annotation to explicitly specify the load balancer IP
- Required because our service is ClusterIP type (used with NEGs) rather than LoadBalancer

## Test plan
- [ ] Deploy changes
- [ ] Verify External DNS creates A record for dev.webapp.u2i.dev pointing to 34.98.112.208
- [ ] Test HTTPS access to https://dev.webapp.u2i.dev

🤖 Generated with [Claude Code](https://claude.ai/code)