### PR TITLE
Use internal-hostname annotation for External DNS

### DIFF
--- a/k8s-clean/overlays/nonprod/kustomization.yaml
+++ b/k8s-clean/overlays/nonprod/kustomization.yaml
@@ -23,14 +23,11 @@ patches:
     name: webapp-service
   patch: |-
     - op: add
-      path: /metadata/annotations/external-dns.alpha.kubernetes.io~1hostname
+      path: /metadata/annotations/external-dns.alpha.kubernetes.io~1internal-hostname
       value: dev.webapp.u2i.dev
     - op: add
       path: /metadata/annotations/external-dns.alpha.kubernetes.io~1ttl
       value: "300"
-    - op: add
-      path: /metadata/annotations/external-dns.alpha.kubernetes.io~1target
-      value: "34.98.112.208"
 
 configMapGenerator:
 - name: webapp-config


### PR DESCRIPTION
## Summary
- Use `external-dns.alpha.kubernetes.io/internal-hostname` annotation for ClusterIP services
- External DNS now has `--publish-internal-services` flag enabled

## Test plan
- [ ] Deploy changes
- [ ] Verify External DNS creates A record automatically
- [ ] Verify dev.webapp.u2i.dev resolves to load balancer IP

🤖 Generated with [Claude Code](https://claude.ai/code)