### PR TITLE
Use ComputeAddress name for External DNS target

### DIFF
--- a/k8s-clean/overlays/nonprod/kustomization.yaml
+++ b/k8s-clean/overlays/nonprod/kustomization.yaml
@@ -23,11 +23,14 @@ patches:
     name: webapp-service
   patch: |-
     - op: add
-      path: /metadata/annotations/external-dns.alpha.kubernetes.io~1internal-hostname
+      path: /metadata/annotations/external-dns.alpha.kubernetes.io~1hostname
       value: dev.webapp.u2i.dev
     - op: add
       path: /metadata/annotations/external-dns.alpha.kubernetes.io~1ttl
       value: "300"
+    - op: add
+      path: /metadata/annotations/external-dns.alpha.kubernetes.io~1target
+      value: webapp-dev-ip
 
 configMapGenerator:
 - name: webapp-config


### PR DESCRIPTION
## Summary
- Use `external-dns.alpha.kubernetes.io/hostname` with `target` annotation
- Reference ComputeAddress by name (`webapp-dev-ip`) instead of hardcoded IP
- External DNS will resolve the address object to get the actual IP

## Why this change?
- When using `target` annotation, External DNS expects `hostname` (not `internal-hostname`)
- Using the address name makes it dynamic - if the IP changes, DNS will update automatically
- This is the proper way to integrate External DNS with Config Connector managed IPs

## Test plan
- [ ] Deploy changes
- [ ] Delete existing manual DNS record
- [ ] Verify External DNS creates A record automatically
- [ ] Verify dev.webapp.u2i.dev resolves to the correct IP

🤖 Generated with [Claude Code](https://claude.ai/code)