### PR TITLE
Use Gateway API for External DNS integration

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -161,3 +161,19 @@ spec:
   ipAddress:
     addressRef:
       name: webapp-dev-ip
+---
+# Gateway for L4 TCP proxy with External DNS support
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: webapp-gateway
+  annotations:
+    networking.gke.io/static-ipv4: webapp-dev-ip
+    external-dns.alpha.kubernetes.io/hostname: dev.webapp.u2i.dev
+    external-dns.alpha.kubernetes.io/ttl: "300"
+spec:
+  gatewayClassName: gke-l4-global-external-managed
+  listeners:
+  - name: https
+    port: 443
+    protocol: TCP

--- a/k8s-clean/overlays/nonprod/kustomization.yaml
+++ b/k8s-clean/overlays/nonprod/kustomization.yaml
@@ -18,19 +18,6 @@ patches:
     - op: replace
       path: /spec/template/spec/containers/0/env/1/value
       value: non-prod
-- target:
-    kind: Service
-    name: webapp-service
-  patch: |-
-    - op: add
-      path: /metadata/annotations/external-dns.alpha.kubernetes.io~1hostname
-      value: dev.webapp.u2i.dev
-    - op: add
-      path: /metadata/annotations/external-dns.alpha.kubernetes.io~1ttl
-      value: "300"
-    - op: add
-      path: /metadata/annotations/external-dns.alpha.kubernetes.io~1target
-      value: webapp-dev-ip
 
 configMapGenerator:
 - name: webapp-config


### PR DESCRIPTION
## Summary
- Add Gateway resource that uses the existing static IP (webapp-dev-ip)
- Gateway exposes port 443 for the L4 TCP proxy
- External DNS watches Gateway status and creates DNS records automatically
- Remove service annotations as Gateway handles DNS now

## Benefits
- Gateway API is the modern GKE approach for load balancing
- External DNS can read the IP from Gateway status.addresses
- No need for manual IP references or workarounds
- Fully GitOps-compliant DNS management

## Test plan
- [ ] Apply terraform changes to update External DNS
- [ ] Deploy Gateway resource through Cloud Deploy
- [ ] Verify Gateway gets the static IP assigned
- [ ] Verify External DNS creates A record automatically
- [ ] Test HTTPS access to dev.webapp.u2i.dev

🤖 Generated with [Claude Code](https://claude.ai/code)