### PR TITLE
Fix Gateway class name for L4 TCP load balancing

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -172,7 +172,7 @@ metadata:
     external-dns.alpha.kubernetes.io/hostname: dev.webapp.u2i.dev
     external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
-  gatewayClassName: gke-l4-global-external-managed
+  gatewayClassName: gke-passthrough-lb-external-managed
   listeners:
   - name: https
     port: 443


### PR DESCRIPTION
## Summary
- Changed Gateway class from `gke-l4-global-external-managed` to `gke-passthrough-lb-external-managed`
- The previous class name doesn't exist on GKE, causing the Gateway to stay in pending state
- The correct class for L4 TCP load balancing with external IPs is `gke-passthrough-lb-external-managed`

## Test plan
- [ ] Verify Gateway resource is accepted after deployment
- [ ] Check that Gateway provisions the load balancer with our static IP
- [ ] Verify External DNS updates the DNS record with the correct IP address

🤖 Generated with [Claude Code](https://claude.ai/code)