### PR TITLE
Fix Gateway and TCPRoute configuration for static IP

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -177,3 +177,16 @@ spec:
   - name: https
     port: 443
     protocol: TCP
+---
+# TCPRoute to connect Gateway to backend service
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: webapp-tcproute
+spec:
+  parentRefs:
+  - name: webapp-gateway
+  rules:
+  - backendRefs:
+    - name: webapp
+      port: 8080

--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -174,19 +174,22 @@ metadata:
 spec:
   gatewayClassName: gke-passthrough-lb-external-managed
   listeners:
-  - name: https
-    port: 443
+  - name: tcp
     protocol: TCP
+    port: 443
+    allowedRoutes:
+      namespaces:
+        from: Same
 ---
 # TCPRoute to connect Gateway to backend service
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
-  name: webapp-tcproute
+  name: webapp-tcp
 spec:
   parentRefs:
   - name: webapp-gateway
   rules:
   - backendRefs:
-    - name: webapp
-      port: 8080
+    - name: webapp-service
+      port: 80


### PR DESCRIPTION
## Summary
- Fixed Gateway configuration to properly bind to static IP
- Added TCPRoute to connect Gateway to webapp-service backend
- Fixed service name (webapp-service) and port (80) in TCPRoute

## Key fixes:
1. **Gateway**: Already had `networking.gke.io/static-ipv4: webapp-dev-ip` annotation ✓
2. **TCPRoute**: Fixed backend reference to use `webapp-service:80` instead of `webapp:8080`
3. **Listener**: Added `allowedRoutes` configuration for proper namespace scoping

## Test plan
- [ ] Verify Gateway gets status.addresses with value 34.98.112.208
- [ ] Verify External DNS updates A record to 34.98.112.208
- [ ] Test application is accessible via https://dev.webapp.u2i.dev
- [ ] Clean up stray DNS record for 34.14.43.4 if needed

🤖 Generated with [Claude Code](https://claude.ai/code)