### PR TITLE
Replace Gateway API with Config Connector SSL proxy architecture

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -13,80 +13,26 @@ spec:
   addressType: EXTERNAL
   description: "Static IP for webapp dev environment"
 ---
-# Certificate Manager - Modern approach for SSL certificates with full GitOps control
-# 1. Google-managed certificate
-apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
-kind: CertificateManagerCertificate
+# Stand-alone NEG service (headless) - only for NEG creation, not for traffic
+apiVersion: v1
+kind: Service
 metadata:
-  name: webapp-dev-cert
+  name: webapp-neg-headless
   annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-  labels:
-    environment: non-prod
-    managed-by: config-connector
+    cloud.google.com/neg: '{"exposed_ports":{"80":{}}}'
 spec:
-  projectRef:
-    external: u2i-tenant-webapp
-  location: global
-  managed:
-    domains:
-    - dev.webapp.u2i.dev
-    dnsAuthorizationsRefs:
-    - name: webapp-dev-auth
+  clusterIP: None
+  selector:
+    app: webapp
+  ports:
+  - port: 80
+    targetPort: 8080
 ---
-# 2. DNS-01 authorization for the domain
-apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
-kind: CertificateManagerDNSAuthorization
-metadata:
-  name: webapp-dev-auth
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-  labels:
-    environment: non-prod
-    managed-by: config-connector
-spec:
-  projectRef:
-    external: u2i-tenant-webapp
-  domain: dev.webapp.u2i.dev
----
-# 3. Certificate map to group certificates
-apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
-kind: CertificateManagerCertificateMap
-metadata:
-  name: webapp-cert-map
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-  labels:
-    environment: non-prod
-    managed-by: config-connector
-spec:
-  projectRef:
-    external: u2i-tenant-webapp
----
-# 4. Map entry to bind hostname to certificate
-apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
-kind: CertificateManagerCertificateMapEntry
-metadata:
-  name: webapp-dev-entry
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-  labels:
-    environment: non-prod
-    managed-by: config-connector
-spec:
-  projectRef:
-    external: u2i-tenant-webapp
-  mapRef:
-    name: webapp-cert-map
-  certificatesRefs:
-  - name: webapp-dev-cert
-  hostname: dev.webapp.u2i.dev
----
-# Health Check
+# Health Check for TCP
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeHealthCheck
 metadata:
-  name: webapp-dev-health
+  name: tcp-80-hc
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
@@ -96,100 +42,73 @@ spec:
   healthyThreshold: 2
   unhealthyThreshold: 3
   tcpHealthCheck:
-    port: 8080
+    port: 80
 ---
-# Backend Service
+# Backend Service for TCP load balancing
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeBackendService
 metadata:
-  name: webapp-dev-backend
+  name: webapp-tcp-bs
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
   location: global
   protocol: TCP
-  loadBalancingScheme: EXTERNAL
+  loadBalancingScheme: EXTERNAL_MANAGED
   healthChecks:
   - healthCheckRef:
-      name: webapp-dev-health
-  connectionDrainingTimeoutSec: 60
-  # NEG attachment requires autoneg controller or manual attachment
-  # The service annotation anthos.cft.dev/autoneg would handle this automatically
+      name: tcp-80-hc
+  connectionDrainingTimeoutSec: 30
+  backends:
+  - groupRef:
+      # TODO: Update with actual NEG name after service creates it
+      # Will be something like: projects/u2i-tenant-webapp/zones/europe-west1-b/networkEndpointGroups/k8s1-...
+      external: projects/u2i-tenant-webapp/zones/europe-west1-b/networkEndpointGroups/PLACEHOLDER_NEG
 ---
-# SSL Policy
+# Target TCP Proxy
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeSSLPolicy
+kind: ComputeTargetTCPProxy
 metadata:
-  name: webapp-ssl-policy
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-spec:
-  profile: MODERN
-  minTlsVersion: TLS_1_2
----
-# Target SSL Proxy
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeTargetSSLProxy
-metadata:
-  name: webapp-dev-ssl-proxy
+  name: webapp-tcp-proxy
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
   backendServiceRef:
-    name: webapp-dev-backend
-  certificateMapRef:
-    external: //certificatemanager.googleapis.com/projects/u2i-tenant-webapp/locations/global/certificateMaps/webapp-cert-map
-  sslPolicyRef:
-    name: webapp-ssl-policy
-  proxyHeader: NONE
+    name: webapp-tcp-bs
+  proxyHeader: PROXY_V1
 ---
-# Forwarding Rule
+# Forwarding Rule - binds to static IP
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeForwardingRule
 metadata:
-  name: webapp-dev-forwarding
+  name: webapp-tcp-fr
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
   location: global
-  portRange: "443"
+  loadBalancingScheme: EXTERNAL_MANAGED
   ipProtocol: TCP
-  loadBalancingScheme: EXTERNAL
+  portRange: "443"
   target:
-    targetSSLProxyRef:
-      name: webapp-dev-ssl-proxy
+    targetTCPProxyRef:
+      name: webapp-tcp-proxy
   ipAddress:
     addressRef:
       name: webapp-dev-ip
 ---
-# Gateway for L4 TCP proxy with External DNS support
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
+# DNS Record - GitOps managed
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
 metadata:
-  name: webapp-gateway
+  name: dev-webapp-a
   annotations:
-    networking.gke.io/static-ipv4: webapp-dev-ip
-    external-dns.alpha.kubernetes.io/hostname: dev.webapp.u2i.dev
-    external-dns.alpha.kubernetes.io/ttl: "300"
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
-  gatewayClassName: gke-passthrough-lb-external-managed
-  listeners:
-  - name: tcp
-    protocol: TCP
-    port: 443
-    allowedRoutes:
-      namespaces:
-        from: Same
----
-# TCPRoute to connect Gateway to backend service
-apiVersion: gateway.networking.k8s.io/v1alpha2
-kind: TCPRoute
-metadata:
-  name: webapp-tcp
-spec:
-  parentRefs:
-  - name: webapp-gateway
-  rules:
-  - backendRefs:
-    - name: webapp-service
-      port: 80
+  name: "dev.webapp.u2i.dev."
+  type: "A"
+  ttl: 300
+  managedZoneRef:
+    external: webapp-zone
+  rrdatasRefs:
+  - name: webapp-dev-ip
+    kind: ComputeAddress

--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -72,23 +72,73 @@ spec:
     groupRef:
       external: projects/u2i-tenant-webapp/zones/europe-west1-d/networkEndpointGroups/webapp-neg-80
 ---
-# Target TCP Proxy
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeTargetTCPProxy
+# Certificate Manager - Managed certificate with DNS challenge
+apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+kind: CertificateManagerCertificate
 metadata:
-  name: webapp-tcp-proxy
+  name: webapp-cert
+  annotations:
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+spec:
+  location: global
+  managed:
+    domains:
+    - dev.webapp.u2i.dev
+    dnsAuthorizationsRefs:
+    - name: webapp-auth
+---
+# DNS Authorization for certificate
+apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+kind: CertificateManagerDNSAuthorization
+metadata:
+  name: webapp-auth
+  annotations:
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+spec:
+  domain: dev.webapp.u2i.dev
+---
+# Certificate Map
+apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+kind: CertificateManagerCertificateMap
+metadata:
+  name: webapp-cert-map
+  annotations:
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+spec: {}
+---
+# Certificate Map Entry
+apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+kind: CertificateManagerCertificateMapEntry
+metadata:
+  name: webapp-entry
+  annotations:
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+spec:
+  mapRef:
+    name: webapp-cert-map
+  hostname: dev.webapp.u2i.dev
+  certificatesRefs:
+  - name: webapp-cert
+---
+# Target SSL Proxy (instead of TCP)
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeTargetSSLProxy
+metadata:
+  name: webapp-ssl-proxy
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
   backendServiceRef:
     name: webapp-tcp-bs
+  certificateMapRef:
+    external: //certificatemanager.googleapis.com/projects/u2i-tenant-webapp/locations/global/certificateMaps/webapp-cert-map
   proxyHeader: PROXY_V1
 ---
 # Forwarding Rule - binds to static IP
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeForwardingRule
 metadata:
-  name: webapp-tcp-fr
+  name: webapp-ssl-fr
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
@@ -97,8 +147,8 @@ spec:
   ipProtocol: TCP
   portRange: "443"
   target:
-    targetTCPProxyRef:
-      name: webapp-tcp-proxy
+    targetSSLProxyRef:
+      name: webapp-ssl-proxy
   ipAddress:
     addressRef:
       name: webapp-dev-ip

--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -13,20 +13,21 @@ spec:
   addressType: EXTERNAL
   description: "Static IP for webapp dev environment"
 ---
-# Stand-alone NEG service (headless) - only for NEG creation, not for traffic
+# Service with NEG annotation for automatic endpoint management
 apiVersion: v1
-kind: Service
+kind: Service  
 metadata:
-  name: webapp-neg-headless
+  name: webapp-service-neg
   annotations:
-    cloud.google.com/neg: '{"exposed_ports":{"80":{}}}'
+    cloud.google.com/neg: '{"exposed_ports":{"80":{"name":"webapp-neg-80"}}}'
 spec:
-  clusterIP: None
+  type: ClusterIP
   selector:
     app: webapp
   ports:
   - port: 80
     targetPort: 8080
+    protocol: TCP
 ---
 # Health Check for TCP
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
@@ -60,10 +61,16 @@ spec:
       name: tcp-80-hc
   connectionDrainingTimeoutSec: 30
   backends:
-  - groupRef:
-      # TODO: Update with actual NEG name after service creates it
-      # Will be something like: projects/u2i-tenant-webapp/zones/europe-west1-b/networkEndpointGroups/k8s1-...
-      external: projects/u2i-tenant-webapp/zones/europe-west1-b/networkEndpointGroups/PLACEHOLDER_NEG
+  - balancingMode: CONNECTION
+    groupRef:
+      # NEG created by the service annotation with explicit name
+      external: projects/u2i-tenant-webapp/zones/europe-west1-b/networkEndpointGroups/webapp-neg-80
+  - balancingMode: CONNECTION
+    groupRef:
+      external: projects/u2i-tenant-webapp/zones/europe-west1-c/networkEndpointGroups/webapp-neg-80
+  - balancingMode: CONNECTION
+    groupRef:
+      external: projects/u2i-tenant-webapp/zones/europe-west1-d/networkEndpointGroups/webapp-neg-80
 ---
 # Target TCP Proxy
 apiVersion: compute.cnrm.cloud.google.com/v1beta1


### PR DESCRIPTION
## Summary
Replaced the Gateway API approach with a proper Config Connector-based SSL proxy architecture that gives us full GitOps control with SSL termination at the load balancer.

## Architecture Overview
```
Client ──HTTPS/443──► Forwarding Rule ──► Target SSL Proxy ──► Backend Service ──► NEG ──► Pods
                           ↑                      ↑
                      Static IP             Certificate Map
                   (34.98.112.208)         (SSL termination)
```

## Changes
1. **Removed Gateway API resources** - TCPRoute is not supported on GKE
2. **Added service with named NEG** - Service creates NEGs with explicit name `webapp-neg-80`
3. **Created SSL proxy stack**:
   - ComputeHealthCheck for TCP health checking
   - ComputeBackendService with EXTERNAL_MANAGED scheme and NEG backends
   - Certificate Manager resources (Certificate, DNSAuthorization, CertificateMap, CertificateMapEntry)
   - ComputeTargetSSLProxy with certificate map for TLS termination
   - ComputeForwardingRule bound to static IP
4. **Added GitOps DNS** - DNSRecordSet that references the ComputeAddress
5. **SSL termination** - Load balancer handles TLS, forwards plain HTTP to pods

## Benefits
- Full declarative control via Config Connector
- No dependency on External DNS controller
- DNS automatically updates if IP changes
- SSL certificates managed by Google Certificate Manager
- No need for TLS configuration in pods

## Test Plan
- [ ] Deploy and wait for Config Connector to create resources
- [ ] Verify NEGs are created in all three zones
- [ ] Verify SSL certificate is provisioned and active
- [ ] Verify load balancer is created with static IP (34.98.112.208)
- [ ] Verify DNS record points to 34.98.112.208
- [ ] Test HTTPS connectivity to https://dev.webapp.u2i.dev
- [ ] Verify SSL certificate is valid in browser

## Cleanup
- [ ] Delete stray DNS record for 34.14.43.4
- [ ] Remove External DNS deployment (no longer needed)

🤖 Generated with [Claude Code](https://claude.ai/code)