### PR TITLE
Fix ComputeBackendService Config Connector syntax

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -60,17 +60,20 @@ spec:
   - healthCheckRef:
       name: tcp-80-hc
   connectionDrainingTimeoutSec: 30
-  backends:
+  backend:
   - balancingMode: CONNECTION
-    groupRef:
+    group:
       # NEG created by the service annotation with explicit name
-      external: projects/u2i-tenant-webapp/zones/europe-west1-b/networkEndpointGroups/webapp-neg-80
+      networkEndpointGroupRef:
+        external: projects/u2i-tenant-webapp/zones/europe-west1-b/networkEndpointGroups/webapp-neg-80
   - balancingMode: CONNECTION
-    groupRef:
-      external: projects/u2i-tenant-webapp/zones/europe-west1-c/networkEndpointGroups/webapp-neg-80
+    group:
+      networkEndpointGroupRef:
+        external: projects/u2i-tenant-webapp/zones/europe-west1-c/networkEndpointGroups/webapp-neg-80
   - balancingMode: CONNECTION
-    groupRef:
-      external: projects/u2i-tenant-webapp/zones/europe-west1-d/networkEndpointGroups/webapp-neg-80
+    group:
+      networkEndpointGroupRef:
+        external: projects/u2i-tenant-webapp/zones/europe-west1-d/networkEndpointGroups/webapp-neg-80
 ---
 # Certificate Manager - Managed certificate with DNS challenge
 apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1


### PR DESCRIPTION
Quick fix for backend service creation issue.

The Config Connector API uses different field names than the GCP API:
- `backends` → `backend`
- `groupRef` → `group.networkEndpointGroupRef`

🤖 Generated with [Claude Code](https://claude.ai/code)