### PR TITLE
Fix Certificate Manager project references

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -86,6 +86,8 @@ metadata:
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
+  projectRef:
+    external: u2i-tenant-webapp
   location: global
   managed:
     domains:
@@ -101,6 +103,8 @@ metadata:
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
+  projectRef:
+    external: u2i-tenant-webapp
   domain: dev.webapp.u2i.dev
 ---
 # Certificate Map
@@ -110,7 +114,9 @@ metadata:
   name: webapp-cert-map
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-spec: {}
+spec:
+  projectRef:
+    external: u2i-tenant-webapp
 ---
 # Certificate Map Entry
 apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
@@ -120,6 +126,8 @@ metadata:
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
+  projectRef:
+    external: u2i-tenant-webapp
   mapRef:
     name: webapp-cert-map
   hostname: dev.webapp.u2i.dev


### PR DESCRIPTION
Add explicit projectRef to all Certificate Manager resources to ensure they're created in the correct project (u2i-tenant-webapp) instead of falling back to namespace name.