### PR TITLE
Switch to L7 Application Load Balancer with External DNS

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -13,13 +13,15 @@ spec:
   addressType: EXTERNAL
   description: "Static IP for webapp dev environment"
 ---
-# Service with NEG annotation for automatic endpoint management
+# Service with NEG annotation for automatic endpoint management (L7)
 apiVersion: v1
 kind: Service  
 metadata:
   name: webapp-service-neg
   annotations:
     cloud.google.com/neg: '{"exposed_ports":{"80":{"name":"webapp-neg-80"}}}'
+    external-dns.alpha.kubernetes.io/hostname: dev.webapp.u2i.dev
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   type: ClusterIP
   selector:
@@ -29,11 +31,11 @@ spec:
     targetPort: 8080
     protocol: TCP
 ---
-# Health Check for TCP
+# Health Check for HTTP
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeHealthCheck
 metadata:
-  name: tcp-80-hc
+  name: webapp-http-hc
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
@@ -42,38 +44,38 @@ spec:
   timeoutSec: 5
   healthyThreshold: 2
   unhealthyThreshold: 3
-  tcpHealthCheck:
+  httpHealthCheck:
     port: 80
+    requestPath: /
 ---
-# Backend Service for TCP load balancing
+# Backend Service for L7 HTTP load balancing
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeBackendService
 metadata:
-  name: webapp-tcp-bs
+  name: webapp-l7-backend
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
   location: global
-  protocol: TCP
+  protocol: HTTP
   loadBalancingScheme: EXTERNAL_MANAGED
   healthChecks:
   - healthCheckRef:
-      name: tcp-80-hc
+      name: webapp-http-hc
   connectionDrainingTimeoutSec: 30
   backend:
-  - balancingMode: CONNECTION
-    maxConnectionsPerEndpoint: 100
+  - balancingMode: RATE
+    maxRatePerEndpoint: 100
     group:
-      # NEG created by the service annotation with explicit name
       networkEndpointGroupRef:
         external: projects/u2i-tenant-webapp/zones/europe-west1-b/networkEndpointGroups/webapp-neg-80
-  - balancingMode: CONNECTION
-    maxConnectionsPerEndpoint: 100
+  - balancingMode: RATE
+    maxRatePerEndpoint: 100
     group:
       networkEndpointGroupRef:
         external: projects/u2i-tenant-webapp/zones/europe-west1-c/networkEndpointGroups/webapp-neg-80
-  - balancingMode: CONNECTION
-    maxConnectionsPerEndpoint: 100
+  - balancingMode: RATE
+    maxRatePerEndpoint: 100
     group:
       networkEndpointGroupRef:
         external: projects/u2i-tenant-webapp/zones/europe-west1-d/networkEndpointGroups/webapp-neg-80
@@ -134,52 +136,50 @@ spec:
   certificatesRefs:
   - name: webapp-cert
 ---
-# Target SSL Proxy (instead of TCP)
+# URL Map for L7 routing
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeTargetSSLProxy
+kind: ComputeURLMap
 metadata:
-  name: webapp-ssl-proxy
+  name: webapp-url-map
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
-  backendServiceRef:
-    name: webapp-tcp-bs
+  location: global
+  defaultService:
+    backendServiceRef:
+      name: webapp-l7-backend
+---
+# Target HTTPS Proxy
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeTargetHTTPSProxy
+metadata:
+  name: webapp-https-proxy
+  annotations:
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+spec:
+  location: global
+  urlMapRef:
+    name: webapp-url-map
   certificateMapRef:
     external: //certificatemanager.googleapis.com/projects/u2i-tenant-webapp/locations/global/certificateMaps/webapp-cert-map
-  proxyHeader: PROXY_V1
 ---
-# Forwarding Rule - binds to static IP
+# Forwarding Rule for L7 HTTPS
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeForwardingRule
 metadata:
-  name: webapp-ssl-fr
+  name: webapp-https-forwarding
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+    external-dns.alpha.kubernetes.io/hostname: dev.webapp.u2i.dev
+    external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
   location: global
   loadBalancingScheme: EXTERNAL_MANAGED
   ipProtocol: TCP
   portRange: "443"
   target:
-    targetSSLProxyRef:
-      name: webapp-ssl-proxy
+    targetHTTPSProxyRef:
+      name: webapp-https-proxy
   ipAddress:
     addressRef:
       name: webapp-dev-ip
----
-# DNS Record - GitOps managed
-apiVersion: dns.cnrm.cloud.google.com/v1beta1
-kind: DNSRecordSet
-metadata:
-  name: dev-webapp-a
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-spec:
-  name: "dev.webapp.u2i.dev."
-  type: "A"
-  ttl: 300
-  managedZoneRef:
-    external: webapp-zone
-  rrdatasRefs:
-  - name: webapp-dev-ip
-    kind: ComputeAddress


### PR DESCRIPTION
## Summary
Switching from L4 TCP/SSL proxy to L7 Application Load Balancer (ALB) for better routing capabilities and integration with GKE.

## Architecture Overview
```
Client ──HTTPS/443──► Forwarding Rule ──► Target HTTPS Proxy ──► URL Map ──► Backend Service ──► NEG ──► Pods
                           ↑                        ↑
                      Static IP              Certificate Map
                   (34.98.112.208)         (SSL termination)
```

## Changes
1. **L7 Load Balancer Stack**:
   - Changed backend service from TCP to HTTP protocol with RATE balancing
   - Added ComputeURLMap for routing configuration
   - Replaced ComputeTargetSSLProxy with ComputeTargetHTTPSProxy
   - Updated forwarding rule to reference HTTPS proxy

2. **Health Check**:
   - Changed from TCP to HTTP health check on path `/`

3. **External DNS**:
   - Added annotations to service for External DNS
   - Forwarding rule also has External DNS annotations as backup

4. **Certificate Manager**:
   - Kept Certificate Manager resources for SSL certificates
   - Certificates attached to Target HTTPS Proxy

## Benefits
- Full L7 routing capabilities (path-based, header-based routing)
- Better observability with L7 metrics
- Integration with Cloud Armor for security
- Support for advanced features like redirects, rewrites
- External DNS automatically manages DNS records

## Test Plan
- [ ] Deploy and wait for resources to be created
- [ ] Verify Certificate Manager provisions certificates
- [ ] Verify load balancer is created with static IP
- [ ] Verify External DNS creates/updates DNS record
- [ ] Test HTTPS connectivity to https://dev.webapp.u2i.dev
- [ ] Verify SSL certificate is valid in browser

## Next Steps
- Enable Certificate Manager API if not already enabled
- Clean up old L4 resources after successful migration

🤖 Generated with [Claude Code](https://claude.ai/code)