### PR TITLE
Use Ingress for L7 load balancer with Certificate Manager

### DIFF
--- a/k8s-clean/overlays/nonprod/cleanup-old-resources.yaml
+++ b/k8s-clean/overlays/nonprod/cleanup-old-resources.yaml
@@ -1,0 +1,50 @@
+# Cleanup old L4 SSL proxy resources
+# Apply with: kubectl delete -f cleanup-old-resources.yaml
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeForwardingRule
+metadata:
+  name: webapp-dev-forwarding
+  namespace: webapp-team
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeTargetSSLProxy
+metadata:
+  name: webapp-dev-ssl-proxy
+  namespace: webapp-team
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeBackendService
+metadata:
+  name: webapp-dev-backend
+  namespace: webapp-team
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeHealthCheck
+metadata:
+  name: webapp-dev-health
+  namespace: webapp-team
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSSLPolicy
+metadata:
+  name: webapp-ssl-policy
+  namespace: webapp-team
+---
+apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+kind: CertificateManagerCertificateMapEntry
+metadata:
+  name: webapp-dev-entry
+  namespace: webapp-team
+---
+apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+kind: CertificateManagerCertificate
+metadata:
+  name: webapp-dev-cert
+  namespace: webapp-team
+---
+apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+kind: CertificateManagerDNSAuthorization
+metadata:
+  name: webapp-dev-auth
+  namespace: webapp-team

--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -1,5 +1,5 @@
 # Config Connector resources for non-prod
-# These create the L4 TCP proxy load balancer with TLS termination
+# These create resources for the L7 HTTPS load balancer
 
 # Reserve static IP address
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
@@ -12,73 +12,6 @@ spec:
   location: global
   addressType: EXTERNAL
   description: "Static IP for webapp dev environment"
----
-# Service with NEG annotation for automatic endpoint management (L7)
-apiVersion: v1
-kind: Service  
-metadata:
-  name: webapp-service-neg
-  annotations:
-    cloud.google.com/neg: '{"exposed_ports":{"80":{"name":"webapp-neg-80"}}}'
-    external-dns.alpha.kubernetes.io/hostname: dev.webapp.u2i.dev
-    external-dns.alpha.kubernetes.io/ttl: "300"
-spec:
-  type: ClusterIP
-  selector:
-    app: webapp
-  ports:
-  - port: 80
-    targetPort: 8080
-    protocol: TCP
----
-# Health Check for HTTP
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeHealthCheck
-metadata:
-  name: webapp-http-hc
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-spec:
-  location: global
-  checkIntervalSec: 10
-  timeoutSec: 5
-  healthyThreshold: 2
-  unhealthyThreshold: 3
-  httpHealthCheck:
-    port: 80
-    requestPath: /
----
-# Backend Service for L7 HTTP load balancing
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeBackendService
-metadata:
-  name: webapp-l7-backend
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-spec:
-  location: global
-  protocol: HTTP
-  loadBalancingScheme: EXTERNAL_MANAGED
-  healthChecks:
-  - healthCheckRef:
-      name: webapp-http-hc
-  connectionDrainingTimeoutSec: 30
-  backend:
-  - balancingMode: RATE
-    maxRatePerEndpoint: 100
-    group:
-      networkEndpointGroupRef:
-        external: projects/u2i-tenant-webapp/zones/europe-west1-b/networkEndpointGroups/webapp-neg-80
-  - balancingMode: RATE
-    maxRatePerEndpoint: 100
-    group:
-      networkEndpointGroupRef:
-        external: projects/u2i-tenant-webapp/zones/europe-west1-c/networkEndpointGroups/webapp-neg-80
-  - balancingMode: RATE
-    maxRatePerEndpoint: 100
-    group:
-      networkEndpointGroupRef:
-        external: projects/u2i-tenant-webapp/zones/europe-west1-d/networkEndpointGroups/webapp-neg-80
 ---
 # Certificate Manager - Managed certificate with DNS challenge
 apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
@@ -136,50 +69,26 @@ spec:
   certificatesRefs:
   - name: webapp-cert
 ---
-# URL Map for L7 routing
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeURLMap
+# Ingress for L7 HTTPS Load Balancer
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
-  name: webapp-url-map
+  name: webapp-ingress
   annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-spec:
-  location: global
-  defaultService:
-    backendServiceRef:
-      name: webapp-l7-backend
----
-# Target HTTPS Proxy
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeTargetHTTPSProxy
-metadata:
-  name: webapp-https-proxy
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-spec:
-  location: global
-  urlMapRef:
-    name: webapp-url-map
-  certificateMapRef:
-    external: //certificatemanager.googleapis.com/projects/u2i-tenant-webapp/locations/global/certificateMaps/webapp-cert-map
----
-# Forwarding Rule for L7 HTTPS
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeForwardingRule
-metadata:
-  name: webapp-https-forwarding
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+    kubernetes.io/ingress.class: gce
+    kubernetes.io/ingress.global-static-ip-name: webapp-dev-ip
+    ingress.gcp.kubernetes.io/pre-shared-cert: webapp-cert-map
     external-dns.alpha.kubernetes.io/hostname: dev.webapp.u2i.dev
     external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
-  location: global
-  loadBalancingScheme: EXTERNAL_MANAGED
-  ipProtocol: TCP
-  portRange: "443"
-  target:
-    targetHTTPSProxyRef:
-      name: webapp-https-proxy
-  ipAddress:
-    addressRef:
-      name: webapp-dev-ip
+  rules:
+  - host: dev.webapp.u2i.dev
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: webapp-service
+            port:
+              number: 80


### PR DESCRIPTION
## Summary
Switching to Kubernetes Ingress resource for L7 HTTPS load balancing, which is the standard approach on GKE.

## Architecture Overview
```
Client ──HTTPS/443──► GCE Ingress Controller ──► Backend Services ──► NEGs ──► Pods
                              ↑                         ↑
                         Static IP               Certificate Map
                      (34.98.112.208)          (SSL termination)
```

## Changes
1. **Removed manual L7 resources** - No more manual URLMap, TargetHTTPSProxy, ForwardingRule definitions
2. **Added Ingress resource** with:
   - GCE ingress class
   - Static IP reference (`webapp-dev-ip`)
   - Certificate Manager certificate map reference
   - External DNS annotations
3. **Kept Certificate Manager** resources for SSL certificate management
4. **Kept static IP** managed by Config Connector
5. **Added cleanup file** for removing old L4 SSL proxy resources

## Benefits
- Simpler configuration - Ingress controller handles all the L7 resource creation
- Standard Kubernetes approach
- Automatic NEG creation and backend service configuration
- External DNS integration via annotations
- Certificate Manager integration for managed SSL certificates

## Test Plan
- [ ] Deploy and verify old resources are deleted
- [ ] Verify Ingress creates L7 load balancer resources automatically
- [ ] Verify load balancer uses the static IP (34.98.112.208)
- [ ] Verify Certificate Manager provisions SSL certificate
- [ ] Verify External DNS updates DNS record
- [ ] Test HTTPS connectivity to https://dev.webapp.u2i.dev

## Cleanup
The PR includes `cleanup-old-resources.yaml` which removes:
- Old forwarding rule, SSL proxy, backend service
- Old health checks and SSL policy
- Old certificate resources

🤖 Generated with [Claude Code](https://claude.ai/code)