### PR TITLE
Fix service type for GCE Ingress

### DIFF
--- a/k8s-clean/base/service.yaml
+++ b/k8s-clean/base/service.yaml
@@ -2,14 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: webapp-service
-  annotations:
-    # Enable NEG creation by GKE
-    cloud.google.com/neg: '{"exposed_ports": {"80": {}}}'
-    # Autoneg controller will attach NEGs to backend service
-    controller.autoneg.dev/neg: |
-      {"backend_services":{"80":[{"name":"webapp-dev-backend","max_connections_per_endpoint":100}]}}
 spec:
-  type: ClusterIP
+  type: NodePort
   selector:
     app: webapp
   ports:


### PR DESCRIPTION
GCE Ingress requires NodePort or LoadBalancer service type. Changed from ClusterIP to NodePort.