### PR TITLE
Fix SSL certificate configuration for Ingress

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -13,61 +13,18 @@ spec:
   addressType: EXTERNAL
   description: "Static IP for webapp dev environment"
 ---
-# Certificate Manager - Managed certificate with DNS challenge
-apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
-kind: CertificateManagerCertificate
+# Google-managed SSL Certificate for Ingress
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSSLCertificate
 metadata:
-  name: webapp-cert
+  name: webapp-dev-cert
   annotations:
     cnrm.cloud.google.com/project-id: u2i-tenant-webapp
 spec:
-  projectRef:
-    external: u2i-tenant-webapp
   location: global
   managed:
     domains:
     - dev.webapp.u2i.dev
-    dnsAuthorizationsRefs:
-    - name: webapp-auth
----
-# DNS Authorization for certificate
-apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
-kind: CertificateManagerDNSAuthorization
-metadata:
-  name: webapp-auth
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-spec:
-  projectRef:
-    external: u2i-tenant-webapp
-  domain: dev.webapp.u2i.dev
----
-# Certificate Map
-apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
-kind: CertificateManagerCertificateMap
-metadata:
-  name: webapp-cert-map
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-spec:
-  projectRef:
-    external: u2i-tenant-webapp
----
-# Certificate Map Entry
-apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
-kind: CertificateManagerCertificateMapEntry
-metadata:
-  name: webapp-entry
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
-spec:
-  projectRef:
-    external: u2i-tenant-webapp
-  mapRef:
-    name: webapp-cert-map
-  hostname: dev.webapp.u2i.dev
-  certificatesRefs:
-  - name: webapp-cert
 ---
 # Ingress for L7 HTTPS Load Balancer
 apiVersion: networking.k8s.io/v1
@@ -77,6 +34,8 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: gce
     kubernetes.io/ingress.global-static-ip-name: webapp-dev-ip
+    ingress.gcp.kubernetes.io/pre-shared-cert: webapp-dev-cert
+    kubernetes.io/ingress.allow-http: "true"
     external-dns.alpha.kubernetes.io/hostname: dev.webapp.u2i.dev
     external-dns.alpha.kubernetes.io/ttl: "300"
 spec:


### PR DESCRIPTION
## Summary
Switch from Certificate Manager to Google-managed SSL certificates, which is the standard approach for GKE Ingress.

## Changes
1. **Replaced Certificate Manager resources** with `ComputeSSLCertificate`
   - Removed CertificateManagerCertificate, DNSAuthorization, CertificateMap, and CertificateMapEntry
   - Added simple ComputeSSLCertificate resource
2. **Updated Ingress annotations**:
   - Added `ingress.gcp.kubernetes.io/pre-shared-cert: webapp-dev-cert`
   - Added `kubernetes.io/ingress.allow-http: "true"` to allow HTTP alongside HTTPS

## Benefits
- Simpler configuration with fewer resources
- No need for Certificate Manager API
- Automatic certificate provisioning and renewal
- Better integration with GKE Ingress controller

## Test Plan
- [ ] Deploy and verify SSL certificate is created
- [ ] Wait for certificate provisioning (can take up to 60 minutes)
- [ ] Verify HTTPS works at https://dev.webapp.u2i.dev
- [ ] Verify HTTP redirects to HTTPS (or works alongside)
- [ ] Check certificate validity in browser

## Notes
Google-managed certificates require:
- DNS must point to the load balancer IP
- Load balancer must be accessible on port 443
- Domain validation happens automatically

🤖 Generated with [Claude Code](https://claude.ai/code)