### PR TITLE
Clean Ingress setup with GKE ManagedCertificate

### DIFF
--- a/k8s-clean/overlays/nonprod/config-connector-resources.yaml
+++ b/k8s-clean/overlays/nonprod/config-connector-resources.yaml
@@ -1,5 +1,4 @@
 # Config Connector resources for non-prod
-# These create resources for the L7 HTTPS load balancer
 
 # Reserve static IP address
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
@@ -13,18 +12,14 @@ spec:
   addressType: EXTERNAL
   description: "Static IP for webapp dev environment"
 ---
-# Google-managed SSL Certificate for Ingress
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeSSLCertificate
+# GKE ManagedCertificate - simple and reliable
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
 metadata:
-  name: webapp-dev-cert
-  annotations:
-    cnrm.cloud.google.com/project-id: u2i-tenant-webapp
+  name: webapp-cert
 spec:
-  location: global
-  managed:
-    domains:
-    - dev.webapp.u2i.dev
+  domains:
+  - dev.webapp.u2i.dev
 ---
 # Ingress for L7 HTTPS Load Balancer
 apiVersion: networking.k8s.io/v1
@@ -32,21 +27,15 @@ kind: Ingress
 metadata:
   name: webapp-ingress
   annotations:
-    kubernetes.io/ingress.class: gce
-    kubernetes.io/ingress.global-static-ip-name: webapp-dev-ip
-    ingress.gcp.kubernetes.io/pre-shared-cert: webapp-dev-cert
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.global-static-ip-name: "webapp-dev-ip"
+    networking.gke.io/managed-certificates: "webapp-cert"
     kubernetes.io/ingress.allow-http: "true"
-    external-dns.alpha.kubernetes.io/hostname: dev.webapp.u2i.dev
+    external-dns.alpha.kubernetes.io/hostname: "dev.webapp.u2i.dev"
     external-dns.alpha.kubernetes.io/ttl: "300"
 spec:
-  rules:
-  - host: dev.webapp.u2i.dev
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: webapp-service
-            port:
-              number: 80
+  defaultBackend:
+    service:
+      name: webapp-service
+      port:
+        number: 80


### PR DESCRIPTION
## Summary
Implementing the clean, recommended approach for GKE Ingress with HTTPS using ManagedCertificate.

## Key Changes
1. **Switched to GKE ManagedCertificate** (`networking.gke.io/v1`)
   - No namespace issues
   - No label validation problems
   - Cluster-local resource
   - Automatic ACME provisioning

2. **Simplified Ingress**
   - Using `defaultBackend` instead of rules
   - Proper annotation format with quoted values
   - Using `networking.gke.io/managed-certificates` annotation

3. **Kept NodePort Service** (already in base/)

## Architecture
```
Client ──HTTPS──► GCE Ingress ──► NodePort Service ──► Pods
                      ↑                 ↑
                 Static IP      ManagedCertificate
              (34.98.112.208)    (auto-provisioned)
```

## Benefits
- Single, clean L7 HTTPS load balancer
- No conflicting resources
- Standard GKE pattern
- Automatic certificate provisioning and renewal
- External DNS integration

## Test Plan
- [ ] Deploy and verify ManagedCertificate is created
- [ ] Check Ingress creates L7 load balancer with static IP
- [ ] Wait for certificate provisioning (5-60 minutes)
- [ ] Verify `.status.loadBalancer.ingress[0].ip` shows 34.98.112.208
- [ ] Test HTTPS access at https://dev.webapp.u2i.dev
- [ ] Verify certificate is valid in browser

## Notes
- Certificate provisioning requires DNS to point to load balancer (already done)
- HTTP is allowed during provisioning, can be disabled later
- External DNS will maintain the A record automatically

🤖 Generated with [Claude Code](https://claude.ai/code)