### PR TITLE
fix: add prod profile alias for Cloud Deploy compatibility

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -57,3 +57,17 @@ profiles:
     kustomize:
       paths:
       - k8s-clean/overlays/production
+# Alias for Cloud Deploy compatibility
+- name: prod
+  build:
+    artifacts:
+    - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-prod/webapp-images/webapp
+      docker:
+        dockerfile: Dockerfile
+    googleCloudBuild:
+      projectId: u2i-tenant-webapp-prod
+      region: europe-west1
+  manifests:
+    kustomize:
+      paths:
+      - k8s-clean/overlays/production


### PR DESCRIPTION
Cloud Deploy pipeline expects 'prod' profile but we had 'production'. Added prod as an alias to fix render failures.