### PR TITLE
fix: add missing profiles to stage-specific skaffold files

### DIFF
--- a/skaffold-prod.yaml
+++ b/skaffold-prod.yaml
@@ -1,0 +1,36 @@
+apiVersion: skaffold/v4beta6
+kind: Config
+metadata:
+  name: webapp-prod-deployment
+build:
+  artifacts:
+  - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-prod/webapp-images/webapp
+    docker:
+      dockerfile: Dockerfile
+  tagPolicy:
+    gitCommit:
+      variant: Tags
+  googleCloudBuild:
+    projectId: u2i-tenant-webapp-prod
+    region: europe-west1
+manifests:
+  kustomize:
+    paths:
+    - k8s-clean/overlays/production
+profiles:
+- name: prod
+  manifests:
+    kustomize:
+      paths:
+      - k8s-clean/overlays/production
+# Add other profiles for Cloud Deploy compatibility
+- name: dev
+  manifests:
+    kustomize:
+      paths:
+      - k8s-clean/overlays/production
+- name: qa
+  manifests:
+    kustomize:
+      paths:
+      - k8s-clean/overlays/production

--- a/skaffold-qa.yaml
+++ b/skaffold-qa.yaml
@@ -10,12 +10,21 @@ build:
   tagPolicy:
     gitCommit:
       variant: Tags
+  googleCloudBuild:
+    projectId: u2i-tenant-webapp
+    region: europe-west1
 manifests:
   kustomize:
     paths:
     - k8s-clean/overlays/qa
 profiles:
 - name: qa
+  manifests:
+    kustomize:
+      paths:
+      - k8s-clean/overlays/qa
+# Add dev profile for Cloud Deploy compatibility
+- name: dev
   manifests:
     kustomize:
       paths:


### PR DESCRIPTION
- Add googleCloudBuild config to skaffold-qa.yaml
- Add dev profile to skaffold-qa.yaml for Cloud Deploy compatibility  
- Create skaffold-prod.yaml with all required profiles

This fixes Cloud Deploy render failures when using stage-specific configs.