### PR TITLE
fix: add id-token permission to promotion workflow

### DIFF
--- a/.github/workflows/cd-promote.yml
+++ b/.github/workflows/cd-promote.yml
@@ -33,6 +33,9 @@ jobs:
   validate-promotion:
     name: Validate Promotion
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       valid: ${{ steps.validate.outputs.valid }}
       release: ${{ steps.find-release.outputs.release }}
@@ -105,6 +108,9 @@ jobs:
     needs: validate-promotion
     if: needs.validate-promotion.outputs.valid == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     environment: ${{ github.event.inputs.to_stage }}
     
     steps:


### PR DESCRIPTION
Add missing id-token write permission required for Workload Identity Federation authentication in the promotion workflow.

This fixes the authentication error when running the stage promotion workflow.