### PR TITLE
chore: trigger deployment after workload identity fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,8 @@ Before each deployment, ensure:
 - **Team Lead**: webapp-team@u2i.com
 - **Security Issues**: security-team@u2i.com  
 - **Platform Support**: platform-team@u2i.com
-- **Compliance Questions**: compliance@u2i.com# Test GitOps Pipeline - Post WIF Fix
+- **Compliance Questions**: compliance@u2i.com
+
+## Deployment Status
+
+Last deployment triggered after workload identity fix.# Test GitOps Pipeline - Post WIF Fix

--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ Before each deployment, ensure:
 - **Team Lead**: webapp-team@u2i.com
 - **Security Issues**: security-team@u2i.com  
 - **Platform Support**: platform-team@u2i.com
-- **Compliance Questions**: compliance@u2i.com# Test GitOps Pipeline
+- **Compliance Questions**: compliance@u2i.com# Test GitOps Pipeline - Post WIF Fix

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Before each deployment, ensure:
 
 ## Deployment Status
 
-Last deployment triggered after workload identity fix.# Test GitOps Pipeline - Post WIF Fix
+Last deployment triggered after workload identity fix.


### PR DESCRIPTION
The workload identity attribute condition has been updated to allow webapp-team-app repository to authenticate. This PR triggers a new deployment to verify the fix.

## Changes
- Added deployment status section to README to trigger a new build

## Context
The previous deployment failed with:
```
Error code unauthorized_client: The given credential is rejected by the attribute condition.
```

This has been fixed by updating the webapp-github-dev workload identity pool provider to include webapp-team-app in the attribute condition.