### PR TITLE
Consolidate preview deployment into single stage

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -29,6 +29,12 @@ jobs:
       with:
         install_components: 'gke-gcloud-auth-plugin'
     
+    - name: Apply Cloud Deploy Configuration
+      run: |
+        gcloud deploy apply --file=clouddeploy-preview.yaml \
+          --region=${{ env.GCP_REGION }} \
+          --project=${{ env.GCP_PROJECT }}
+    
     - name: Deploy Preview
       id: deploy
       run: |

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -29,12 +29,6 @@ jobs:
       with:
         install_components: 'gke-gcloud-auth-plugin'
     
-    - name: Apply Cloud Deploy Configuration
-      run: |
-        gcloud deploy apply --file=clouddeploy-preview.yaml \
-          --region=${{ env.GCP_REGION }} \
-          --project=${{ env.GCP_PROJECT }}
-    
     - name: Deploy Preview
       id: deploy
       run: |

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -42,7 +42,7 @@ jobs:
           --region=${{ env.GCP_REGION }} \
           --project=${{ env.GCP_PROJECT }} \
           --skaffold-file=skaffold-gateway-preview.yaml \
-          --to-target=preview-gke \
+          --to-target=preview-gke-config \
           --deploy-parameters="DOMAIN=${DOMAIN},PREVIEW_NAME=${PREVIEW_NAME},NAMESPACE=${NAMESPACE},CERT_NAME=webapp-preview-cert-${PREVIEW_NAME},CERT_ENTRY_NAME=webapp-preview-entry-${PREVIEW_NAME},ROUTE_NAME=webapp-preview-route-${PREVIEW_NAME},CERT_DESCRIPTION=Certificate for ${DOMAIN},API_URL=https://api-${DOMAIN},ENV=preview,STAGE=preview,BOUNDARY=nonprod,TIER=preview,NAME_PREFIX=preview-,SERVICE_NAME=preview-webapp-service"
         
         echo "preview_url=https://${DOMAIN}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -42,7 +42,7 @@ jobs:
           --region=${{ env.GCP_REGION }} \
           --project=${{ env.GCP_PROJECT }} \
           --skaffold-file=skaffold-gateway-preview.yaml \
-          --to-target=preview-gke-cert \
+          --to-target=preview-gke \
           --deploy-parameters="DOMAIN=${DOMAIN},PREVIEW_NAME=${PREVIEW_NAME},NAMESPACE=${NAMESPACE},CERT_NAME=webapp-preview-cert-${PREVIEW_NAME},CERT_ENTRY_NAME=webapp-preview-entry-${PREVIEW_NAME},ROUTE_NAME=webapp-preview-route-${PREVIEW_NAME},CERT_DESCRIPTION=Certificate for ${DOMAIN},API_URL=https://api-${DOMAIN},ENV=preview,STAGE=preview,BOUNDARY=nonprod,TIER=preview,NAME_PREFIX=preview-,SERVICE_NAME=preview-webapp-service"
         
         echo "preview_url=https://${DOMAIN}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -43,20 +43,7 @@ jobs:
           --project=${{ env.GCP_PROJECT }} \
           --skaffold-file=skaffold-gateway-preview.yaml \
           --to-target=preview-gke \
-          --deploy-parameters="DOMAIN=${DOMAIN}" \
-          --deploy-parameters="PREVIEW_NAME=${PREVIEW_NAME}" \
-          --deploy-parameters="NAMESPACE=${NAMESPACE}" \
-          --deploy-parameters="CERT_NAME=webapp-preview-cert-${PREVIEW_NAME}" \
-          --deploy-parameters="CERT_ENTRY_NAME=webapp-preview-entry-${PREVIEW_NAME}" \
-          --deploy-parameters="ROUTE_NAME=webapp-preview-route-${PREVIEW_NAME}" \
-          --deploy-parameters="CERT_DESCRIPTION=Certificate for ${DOMAIN}" \
-          --deploy-parameters="API_URL=https://api-${DOMAIN}" \
-          --deploy-parameters="ENV=preview" \
-          --deploy-parameters="STAGE=preview" \
-          --deploy-parameters="BOUNDARY=nonprod" \
-          --deploy-parameters="TIER=preview" \
-          --deploy-parameters="NAME_PREFIX=preview-" \
-          --deploy-parameters="SERVICE_NAME=preview-webapp-service"
+          --deploy-parameters="DOMAIN=${DOMAIN},PREVIEW_NAME=${PREVIEW_NAME},NAMESPACE=${NAMESPACE},CERT_NAME=webapp-preview-cert-${PREVIEW_NAME},CERT_ENTRY_NAME=webapp-preview-entry-${PREVIEW_NAME},ROUTE_NAME=webapp-preview-route-${PREVIEW_NAME},CERT_DESCRIPTION=Certificate for ${DOMAIN},API_URL=https://api-${DOMAIN},ENV=preview,STAGE=preview,BOUNDARY=nonprod,TIER=preview,NAME_PREFIX=preview-,SERVICE_NAME=preview-webapp-service"
         
         echo "preview_url=https://${DOMAIN}" >> $GITHUB_OUTPUT
     

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -42,7 +42,7 @@ jobs:
           --region=${{ env.GCP_REGION }} \
           --project=${{ env.GCP_PROJECT }} \
           --skaffold-file=skaffold-gateway-preview.yaml \
-          --to-target=preview-gke-config \
+          --to-target=preview-gke \
           --deploy-parameters="DOMAIN=${DOMAIN},PREVIEW_NAME=${PREVIEW_NAME},NAMESPACE=${NAMESPACE},CERT_NAME=webapp-preview-cert-${PREVIEW_NAME},CERT_ENTRY_NAME=webapp-preview-entry-${PREVIEW_NAME},ROUTE_NAME=webapp-preview-route-${PREVIEW_NAME},CERT_DESCRIPTION=Certificate for ${DOMAIN},API_URL=https://api-${DOMAIN},ENV=preview,STAGE=preview,BOUNDARY=nonprod,TIER=preview,NAME_PREFIX=preview-,SERVICE_NAME=preview-webapp-service"
         
         echo "preview_url=https://${DOMAIN}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -43,7 +43,20 @@ jobs:
           --project=${{ env.GCP_PROJECT }} \
           --skaffold-file=skaffold-gateway-preview.yaml \
           --to-target=preview-gke \
-          --deploy-parameters="DOMAIN=${DOMAIN},PREVIEW_NAME=${PREVIEW_NAME},NAMESPACE=${NAMESPACE},CERT_NAME=webapp-preview-cert-${PREVIEW_NAME},CERT_ENTRY_NAME=webapp-preview-entry-${PREVIEW_NAME},ROUTE_NAME=webapp-preview-route-${PREVIEW_NAME},CERT_DESCRIPTION=Certificate for ${DOMAIN},API_URL=https://api-${DOMAIN},ENV=preview,STAGE=preview,BOUNDARY=nonprod,TIER=preview,NAME_PREFIX=preview-,SERVICE_NAME=preview-webapp-service"
+          --deploy-parameters="DOMAIN=${DOMAIN}" \
+          --deploy-parameters="PREVIEW_NAME=${PREVIEW_NAME}" \
+          --deploy-parameters="NAMESPACE=${NAMESPACE}" \
+          --deploy-parameters="CERT_NAME=webapp-preview-cert-${PREVIEW_NAME}" \
+          --deploy-parameters="CERT_ENTRY_NAME=webapp-preview-entry-${PREVIEW_NAME}" \
+          --deploy-parameters="ROUTE_NAME=webapp-preview-route-${PREVIEW_NAME}" \
+          --deploy-parameters="CERT_DESCRIPTION=Certificate for ${DOMAIN}" \
+          --deploy-parameters="API_URL=https://api-${DOMAIN}" \
+          --deploy-parameters="ENV=preview" \
+          --deploy-parameters="STAGE=preview" \
+          --deploy-parameters="BOUNDARY=nonprod" \
+          --deploy-parameters="TIER=preview" \
+          --deploy-parameters="NAME_PREFIX=preview-" \
+          --deploy-parameters="SERVICE_NAME=preview-webapp-service"
         
         echo "preview_url=https://${DOMAIN}" >> $GITHUB_OUTPUT
     

--- a/clouddeploy-preview.yaml
+++ b/clouddeploy-preview.yaml
@@ -1,5 +1,5 @@
 # Cloud Deploy Configuration for Preview Deployments
-# Sequential deployment using predeploy hooks: cert → infra → app
+# Two-phase deployment: Config Connector → Infra/App
 
 apiVersion: deploy.cloud.google.com/v1
 kind: DeliveryPipeline
@@ -9,17 +9,17 @@ metadata:
     compliance: iso27001-soc2-gdpr
     team: webapp-team
     purpose: preview
-description: "Preview deploy: cert → infra → app as one unit"
+description: "Preview deployment: Config Connector resources → Infra/App"
 
 serialPipeline:
   stages:
   - targetId: preview-gke
-    profiles: ["app-only"]  # Only run the app profile as main deploy
+    profiles: ["infra-app"]  # Main deploy profile
     strategy:
       standard:
         verify: false
         predeploy:
-          actions: ["cert-action", "infra-action"]  # Run these in order first
+          actions: ["deploy-config-connector"]  # Config Connector resources first
     deployParameters:
     - values:
         DOMAIN: ""
@@ -46,7 +46,7 @@ metadata:
     compliance: iso27001-soc2-gdpr
     environment: preview
     data-residency: eu
-description: "All-in-one preview stage with sequential deployment"
+description: "Preview deployment target"
 
 gke:
   cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster

--- a/clouddeploy-preview.yaml
+++ b/clouddeploy-preview.yaml
@@ -1,5 +1,5 @@
 # Cloud Deploy Configuration for Preview Deployments
-# Supports dynamic domains like foo.webapp.u2i.dev
+# Consolidated single-stage deployment: cert → infra → app
 
 apiVersion: deploy.cloud.google.com/v1
 kind: DeliveryPipeline
@@ -9,13 +9,13 @@ metadata:
     compliance: iso27001-soc2-gdpr
     team: webapp-team
     purpose: preview
-description: "Preview deployment pipeline with parameterized domains"
+description: "Preview deploy: cert → infra → app as one unit"
 
 serialPipeline:
   stages:
-  # Stage 1: Create certificate and wait for it to be ready
-  - targetId: preview-gke-cert
-    profiles: ["cert-only"]
+  - targetId: preview-gke
+    # Run these three Skaffold profiles in order as one stage
+    profiles: ["cert-only", "infra-only", "app-only"]
     strategy:
       standard:
         verify: false
@@ -27,20 +27,6 @@ serialPipeline:
         CERT_NAME: ""
         CERT_ENTRY_NAME: ""
         CERT_DESCRIPTION: ""
-  
-  # Stage 2: Deploy infrastructure (service, configmap, routes)
-  - targetId: preview-gke-infra
-    profiles: ["infra-only"]
-    strategy:
-      standard:
-        verify: false
-    deployParameters:
-    - values:
-        DOMAIN: ""
-        PREVIEW_NAME: ""
-        NAMESPACE: ""
-        CERT_NAME: ""
-        CERT_ENTRY_NAME: ""
         ROUTE_NAME: ""
         API_URL: ""
         ENV: ""
@@ -49,36 +35,17 @@ serialPipeline:
         TIER: ""
         NAME_PREFIX: ""
         SERVICE_NAME: ""
-  
-  # Stage 3: Deploy the application
-  - targetId: preview-gke-app
-    profiles: ["app-only"]
-    strategy:
-      standard:
-        verify: false
-    deployParameters:
-    - values:
-        DOMAIN: ""
-        PREVIEW_NAME: ""
-        NAMESPACE: ""
-        API_URL: ""
-        ENV: ""
-        STAGE: ""
-        BOUNDARY: ""
-        TIER: ""
-        NAME_PREFIX: ""
 
 ---
 apiVersion: deploy.cloud.google.com/v1
 kind: Target
 metadata:
-  name: preview-gke-cert
+  name: preview-gke
   labels:
     compliance: iso27001-soc2-gdpr
     environment: preview
     data-residency: eu
-    stage: certificate
-description: "Certificate provisioning stage"
+description: "All-in-one preview stage"
 
 gke:
   cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
@@ -87,79 +54,3 @@ executionConfigs:
 - usages: [RENDER, DEPLOY]
   serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
   artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
-
----
-apiVersion: deploy.cloud.google.com/v1
-kind: Target
-metadata:
-  name: preview-gke-infra
-  labels:
-    compliance: iso27001-soc2-gdpr
-    environment: preview
-    data-residency: eu
-    stage: infrastructure
-description: "Infrastructure deployment stage"
-
-gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
-  
-executionConfigs:
-- usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
-
----
-apiVersion: deploy.cloud.google.com/v1
-kind: Target
-metadata:
-  name: preview-gke-app
-  labels:
-    compliance: iso27001-soc2-gdpr
-    environment: preview
-    data-residency: eu
-    stage: application
-description: "Application deployment stage"
-
-gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
-  
-executionConfigs:
-- usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
-
----
-apiVersion: deploy.cloud.google.com/v1
-kind: Automation
-metadata:
-  name: webapp-preview-pipeline/promote-cert-to-infra
-  labels:
-    compliance: iso27001-soc2-gdpr
-description: "Auto-promote from cert to infra stage when cert is ready"
-suspended: false
-serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-selector:
-- target:
-    id: preview-gke-cert
-rules:
-- promoteReleaseRule:
-    id: promote-to-infra
-    toTargetId: preview-gke-infra
-
----
-apiVersion: deploy.cloud.google.com/v1
-kind: Automation
-metadata:
-  name: webapp-preview-pipeline/promote-infra-to-app
-  labels:
-    compliance: iso27001-soc2-gdpr
-description: "Auto-promote from infra to app stage when infra is ready"
-suspended: false
-serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-selector:
-- target:
-    id: preview-gke-infra
-rules:
-- promoteReleaseRule:
-    id: promote-to-app
-    toTargetId: preview-gke-app

--- a/clouddeploy-preview.yaml
+++ b/clouddeploy-preview.yaml
@@ -19,22 +19,6 @@ serialPipeline:
     strategy:
       standard:
         verify: false
-    deployParameters:
-    - values:
-        DOMAIN: ""
-        PREVIEW_NAME: ""
-        NAMESPACE: ""
-        CERT_NAME: ""
-        CERT_ENTRY_NAME: ""
-        CERT_DESCRIPTION: ""
-        ROUTE_NAME: ""
-        API_URL: ""
-        ENV: ""
-        STAGE: ""
-        BOUNDARY: ""
-        TIER: ""
-        NAME_PREFIX: ""
-        SERVICE_NAME: ""
 
 ---
 apiVersion: deploy.cloud.google.com/v1

--- a/clouddeploy-preview.yaml
+++ b/clouddeploy-preview.yaml
@@ -1,5 +1,5 @@
 # Cloud Deploy Configuration for Preview Deployments
-# Two-phase deployment: Config Connector → Infra/App
+# Two-stage deployment: Config Connector → Infra/App
 
 apiVersion: deploy.cloud.google.com/v1
 kind: DeliveryPipeline
@@ -9,33 +9,80 @@ metadata:
     compliance: iso27001-soc2-gdpr
     team: webapp-team
     purpose: preview
-description: "Preview deployment: Config Connector resources → Infra/App"
+description: "Preview deployment: Config Connector → Infra/App"
 
 serialPipeline:
   stages:
-  - targetId: preview-gke
-    profiles: ["infra-app"]  # Main deploy profile
+  # Stage 1: Config Connector resources (namespace + cert)
+  - targetId: preview-gke-config
+    profiles: ["config-connector"]
     strategy:
       standard:
         verify: false
-        predeploy:
-          actions: ["deploy-config-connector"]  # Config Connector resources first
+  
+  # Stage 2: Infrastructure + Application
+  - targetId: preview-gke-infra-app
+    profiles: ["infra-app"]
+    strategy:
+      standard:
+        verify: false
 
 ---
 apiVersion: deploy.cloud.google.com/v1
 kind: Target
 metadata:
-  name: preview-gke
+  name: preview-gke-config
   labels:
     compliance: iso27001-soc2-gdpr
     environment: preview
     data-residency: eu
-description: "Preview deployment target"
+    stage: config-connector
+description: "Config Connector deployment stage"
 
 gke:
   cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
   
 executionConfigs:
-- usages: [RENDER, DEPLOY, PREDEPLOY]
+- usages: [RENDER, DEPLOY]
   serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
   artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
+
+---
+apiVersion: deploy.cloud.google.com/v1
+kind: Target
+metadata:
+  name: preview-gke-infra-app
+  labels:
+    compliance: iso27001-soc2-gdpr
+    environment: preview
+    data-residency: eu
+    stage: infra-app
+description: "Infrastructure and application deployment stage"
+
+gke:
+  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
+  
+executionConfigs:
+- usages: [RENDER, DEPLOY]
+  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
+  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
+
+---
+# Automation to immediately promote from stage 1 to stage 2
+apiVersion: deploy.cloud.google.com/v1
+kind: Automation
+metadata:
+  name: webapp-preview-pipeline/promote-config-to-infra
+  labels:
+    compliance: iso27001-soc2-gdpr
+description: "Auto-promote from Config Connector to Infra/App stage"
+suspended: false
+serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
+selector:
+- target:
+    id: preview-gke-config
+rules:
+- promoteReleaseRule:
+    id: promote-to-infra-app
+    toTargetId: preview-gke-infra-app
+    wait: 0m

--- a/clouddeploy-preview.yaml
+++ b/clouddeploy-preview.yaml
@@ -52,6 +52,6 @@ gke:
   cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
   
 executionConfigs:
-- usages: [RENDER, DEPLOY]
+- usages: [RENDER, DEPLOY, PREDEPLOY]
   serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
   artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts

--- a/clouddeploy-preview.yaml
+++ b/clouddeploy-preview.yaml
@@ -1,5 +1,5 @@
 # Cloud Deploy Configuration for Preview Deployments
-# Two-stage deployment: Config Connector → Infra/App
+# Single-stage deployment with ordered resources
 
 apiVersion: deploy.cloud.google.com/v1
 kind: DeliveryPipeline
@@ -9,20 +9,12 @@ metadata:
     compliance: iso27001-soc2-gdpr
     team: webapp-team
     purpose: preview
-description: "Preview deployment: Config Connector → Infra/App"
+description: "Preview deployment pipeline"
 
 serialPipeline:
   stages:
-  # Stage 1: Config Connector resources (namespace + cert)
-  - targetId: preview-gke-config
-    profiles: ["config-connector"]
-    strategy:
-      standard:
-        verify: false
-  
-  # Stage 2: Infrastructure + Application
-  - targetId: preview-gke-infra-app
-    profiles: ["infra-app"]
+  - targetId: preview-gke
+    profiles: ["preview-all"]  # Single profile with all resources in order
     strategy:
       standard:
         verify: false
@@ -31,13 +23,12 @@ serialPipeline:
 apiVersion: deploy.cloud.google.com/v1
 kind: Target
 metadata:
-  name: preview-gke-config
+  name: preview-gke
   labels:
     compliance: iso27001-soc2-gdpr
     environment: preview
     data-residency: eu
-    stage: config-connector
-description: "Config Connector deployment stage"
+description: "Preview deployment target"
 
 gke:
   cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
@@ -46,43 +37,3 @@ executionConfigs:
 - usages: [RENDER, DEPLOY]
   serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
   artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
-
----
-apiVersion: deploy.cloud.google.com/v1
-kind: Target
-metadata:
-  name: preview-gke-infra-app
-  labels:
-    compliance: iso27001-soc2-gdpr
-    environment: preview
-    data-residency: eu
-    stage: infra-app
-description: "Infrastructure and application deployment stage"
-
-gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
-  
-executionConfigs:
-- usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
-
----
-# Automation to immediately promote from stage 1 to stage 2
-apiVersion: deploy.cloud.google.com/v1
-kind: Automation
-metadata:
-  name: webapp-preview-pipeline/promote-config-to-infra
-  labels:
-    compliance: iso27001-soc2-gdpr
-description: "Auto-promote from Config Connector to Infra/App stage"
-suspended: false
-serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-selector:
-- target:
-    id: preview-gke-config
-rules:
-- promoteReleaseRule:
-    id: promote-to-infra-app
-    toTargetId: preview-gke-infra-app
-    wait: 0m

--- a/clouddeploy-preview.yaml
+++ b/clouddeploy-preview.yaml
@@ -20,22 +20,6 @@ serialPipeline:
         verify: false
         predeploy:
           actions: ["deploy-config-connector"]  # Config Connector resources first
-    deployParameters:
-    - values:
-        DOMAIN: ""
-        PREVIEW_NAME: ""
-        NAMESPACE: ""
-        CERT_NAME: ""
-        CERT_ENTRY_NAME: ""
-        CERT_DESCRIPTION: ""
-        ROUTE_NAME: ""
-        API_URL: ""
-        ENV: ""
-        STAGE: ""
-        BOUNDARY: ""
-        TIER: ""
-        NAME_PREFIX: ""
-        SERVICE_NAME: ""
 
 ---
 apiVersion: deploy.cloud.google.com/v1

--- a/clouddeploy-preview.yaml
+++ b/clouddeploy-preview.yaml
@@ -1,5 +1,5 @@
 # Cloud Deploy Configuration for Preview Deployments
-# Consolidated single-stage deployment: cert → infra → app
+# Sequential deployment using predeploy hooks: cert → infra → app
 
 apiVersion: deploy.cloud.google.com/v1
 kind: DeliveryPipeline
@@ -14,11 +14,28 @@ description: "Preview deploy: cert → infra → app as one unit"
 serialPipeline:
   stages:
   - targetId: preview-gke
-    # Run these three Skaffold profiles in order as one stage
-    profiles: ["cert-only", "infra-only", "app-only"]
+    profiles: ["app-only"]  # Only run the app profile as main deploy
     strategy:
       standard:
         verify: false
+        predeploy:
+          actions: ["cert-action", "infra-action"]  # Run these in order first
+    deployParameters:
+    - values:
+        DOMAIN: ""
+        PREVIEW_NAME: ""
+        NAMESPACE: ""
+        CERT_NAME: ""
+        CERT_ENTRY_NAME: ""
+        CERT_DESCRIPTION: ""
+        ROUTE_NAME: ""
+        API_URL: ""
+        ENV: ""
+        STAGE: ""
+        BOUNDARY: ""
+        TIER: ""
+        NAME_PREFIX: ""
+        SERVICE_NAME: ""
 
 ---
 apiVersion: deploy.cloud.google.com/v1
@@ -29,7 +46,7 @@ metadata:
     compliance: iso27001-soc2-gdpr
     environment: preview
     data-residency: eu
-description: "All-in-one preview stage"
+description: "All-in-one preview stage with sequential deployment"
 
 gke:
   cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster

--- a/skaffold-gateway-preview.yaml
+++ b/skaffold-gateway-preview.yaml
@@ -25,6 +25,36 @@ deploy:
       global: ["--request-timeout=600s"]
   statusCheckDeadlineSeconds: 1200
 profiles:
+# Profile for Config Connector resources (namespace + cert)
+- name: config-connector
+  manifests:
+    kustomize:
+      paths:
+      - k8s-clean/overlays/preview-gateway-cert
+      buildArgs:
+      - --load-restrictor=LoadRestrictionsNone
+  deploy:
+    kubectl:
+      flags:
+        apply: ["--wait=true", "--server-side"]
+        global: ["--request-timeout=600s"]
+
+# Profile for remaining infra + app (includes docker build)
+- name: infra-app
+  manifests:
+    kustomize:
+      paths:
+      - k8s-clean/overlays/preview-gateway-infra
+      - k8s-clean/overlays/preview-gateway
+      buildArgs:
+      - --load-restrictor=LoadRestrictionsNone
+  deploy:
+    kubectl:
+      flags:
+        apply: ["--wait=true"]
+        global: ["--request-timeout=300s"]
+
+# Legacy profiles for compatibility
 - name: cert-only
   manifests:
     kustomize:
@@ -65,33 +95,24 @@ profiles:
         global: ["--request-timeout=300s"]
 
 customActions:
-- name: cert-action
+- name: deploy-config-connector
   containers:
-  - name: run-cert
+  - name: config-connector-deploy
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
     command: ["/bin/sh"]
     args:
     - -c
     - |
-      echo "Deploying certificate resources..."
-      # The manifests are already rendered by Cloud Deploy with parameters substituted
-      # We just need to apply them
-      kubectl apply -f <(skaffold render -p cert-only) \
+      echo "Deploying Config Connector resources (namespace + cert)..."
+      # Apply the pre-rendered config-connector manifests
+      kubectl apply -f <(skaffold render -p config-connector) \
         --wait=true \
+        --server-side \
         --timeout=600s
-      echo "Certificate deployment complete"
-
-- name: infra-action  
-  containers:
-  - name: run-infra
-    image: gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
-    command: ["/bin/sh"]
-    args:
-    - -c
-    - |
-      echo "Deploying infrastructure resources..."
-      # The manifests are already rendered by Cloud Deploy with parameters substituted
-      kubectl apply -f <(skaffold render -p infra-only) \
-        --wait=true \
-        --timeout=60s
-      echo "Infrastructure deployment complete"
+      
+      # Wait for namespace to be ready
+      echo "Waiting for namespace to be ready..."
+      kubectl wait namespace/${NAMESPACE} --for=jsonpath='{.status.phase}'=Active --timeout=60s || true
+      
+      # Note: Certificate readiness is checked by Config Connector itself
+      echo "Config Connector deployment complete"

--- a/skaffold-gateway-preview.yaml
+++ b/skaffold-gateway-preview.yaml
@@ -25,7 +25,26 @@ deploy:
       global: ["--request-timeout=600s"]
   statusCheckDeadlineSeconds: 1200
 profiles:
-# Profile for Config Connector resources (namespace + cert)
+# Single profile with all resources in dependency order
+- name: preview-all
+  manifests:
+    kustomize:
+      paths:
+      # 1. Config Connector resources first (namespace + cert)
+      - k8s-clean/overlays/preview-gateway-cert
+      # 2. Infrastructure resources (service, network policy, routes)
+      - k8s-clean/overlays/preview-gateway-infra
+      # 3. Application deployment
+      - k8s-clean/overlays/preview-gateway
+      buildArgs:
+      - --load-restrictor=LoadRestrictionsNone
+  deploy:
+    kubectl:
+      flags:
+        apply: ["--wait=true", "--server-side"]
+        global: ["--request-timeout=600s"]
+
+# Legacy profiles kept for compatibility
 - name: config-connector
   manifests:
     kustomize:
@@ -39,7 +58,6 @@ profiles:
         apply: ["--wait=true", "--server-side"]
         global: ["--request-timeout=600s"]
 
-# Profile for remaining infra + app (includes docker build)
 - name: infra-app
   manifests:
     kustomize:

--- a/skaffold-gateway-preview.yaml
+++ b/skaffold-gateway-preview.yaml
@@ -104,7 +104,8 @@ customActions:
     - -c
     - |
       echo "Deploying Config Connector resources (namespace + cert)..."
-      # Let skaffold deploy handle rendering and applying with proper parameter substitution
+      # Since we removed deployParameters from pipeline, we need to pass them explicitly
+      # Cloud Deploy will set these as environment variables from --deploy-parameters
       skaffold deploy -p config-connector \
         --status-check=false
       echo "Config Connector deployment complete"

--- a/skaffold-gateway-preview.yaml
+++ b/skaffold-gateway-preview.yaml
@@ -98,21 +98,13 @@ customActions:
 - name: deploy-config-connector
   containers:
   - name: config-connector-deploy
-    image: gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+    image: gcr.io/k8s-skaffold/skaffold:latest
     command: ["/bin/sh"]
     args:
     - -c
     - |
       echo "Deploying Config Connector resources (namespace + cert)..."
-      # Apply the pre-rendered config-connector manifests
-      kubectl apply -f <(skaffold render -p config-connector) \
-        --wait=true \
-        --server-side \
-        --timeout=600s
-      
-      # Wait for namespace to be ready
-      echo "Waiting for namespace to be ready..."
-      kubectl wait namespace/${NAMESPACE} --for=jsonpath='{.status.phase}'=Active --timeout=60s || true
-      
-      # Note: Certificate readiness is checked by Config Connector itself
+      # Let skaffold deploy handle rendering and applying with proper parameter substitution
+      skaffold deploy -p config-connector \
+        --status-check=false
       echo "Config Connector deployment complete"

--- a/skaffold-gateway-preview.yaml
+++ b/skaffold-gateway-preview.yaml
@@ -41,7 +41,7 @@ profiles:
   deploy:
     kubectl:
       flags:
-        apply: ["--wait=true", "--server-side"]
+        apply: ["--wait=true"]
         global: ["--request-timeout=600s"]
 
 # Legacy profiles kept for compatibility
@@ -55,7 +55,7 @@ profiles:
   deploy:
     kubectl:
       flags:
-        apply: ["--wait=true", "--server-side"]
+        apply: ["--wait=true"]
         global: ["--request-timeout=600s"]
 
 - name: infra-app

--- a/skaffold-gateway-preview.yaml
+++ b/skaffold-gateway-preview.yaml
@@ -93,19 +93,3 @@ profiles:
       flags:
         apply: ["--wait=true"]
         global: ["--request-timeout=300s"]
-
-customActions:
-- name: deploy-config-connector
-  containers:
-  - name: config-connector-deploy
-    image: gcr.io/k8s-skaffold/skaffold:latest
-    command: ["/bin/sh"]
-    args:
-    - -c
-    - |
-      echo "Deploying Config Connector resources (namespace + cert)..."
-      # Specify the config file explicitly
-      skaffold deploy -p config-connector \
-        --filename=skaffold-gateway-preview.yaml \
-        --status-check=false
-      echo "Config Connector deployment complete"

--- a/skaffold-gateway-preview.yaml
+++ b/skaffold-gateway-preview.yaml
@@ -63,3 +63,33 @@ profiles:
       flags:
         apply: ["--wait=true"]
         global: ["--request-timeout=300s"]
+
+customActions:
+- name: cert-action
+  containers:
+  - name: run-cert
+    image: gcr.io/k8s-skaffold/skaffold:latest
+    command: ["/bin/sh"]
+    args:
+    - -c
+    - |
+      skaffold deploy -p cert-only \
+        --status-check=false \
+        --kube-context=$(kubectl config current-context)
+      # Wait for certificate to be ready if needed
+      # kubectl wait certificate/${CERT_NAME} \
+      #   --namespace=${NAMESPACE} \
+      #   --for=condition=Ready \
+      #   --timeout=300s || true
+
+- name: infra-action  
+  containers:
+  - name: run-infra
+    image: gcr.io/k8s-skaffold/skaffold:latest
+    command: ["/bin/sh"]
+    args:
+    - -c
+    - |
+      skaffold deploy -p infra-only \
+        --status-check=false \
+        --kube-context=$(kubectl config current-context)

--- a/skaffold-gateway-preview.yaml
+++ b/skaffold-gateway-preview.yaml
@@ -68,28 +68,30 @@ customActions:
 - name: cert-action
   containers:
   - name: run-cert
-    image: gcr.io/k8s-skaffold/skaffold:latest
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
     command: ["/bin/sh"]
     args:
     - -c
     - |
-      skaffold deploy -p cert-only \
-        --status-check=false \
-        --kube-context=$(kubectl config current-context)
-      # Wait for certificate to be ready if needed
-      # kubectl wait certificate/${CERT_NAME} \
-      #   --namespace=${NAMESPACE} \
-      #   --for=condition=Ready \
-      #   --timeout=300s || true
+      echo "Deploying certificate resources..."
+      # The manifests are already rendered by Cloud Deploy with parameters substituted
+      # We just need to apply them
+      kubectl apply -f <(skaffold render -p cert-only) \
+        --wait=true \
+        --timeout=600s
+      echo "Certificate deployment complete"
 
 - name: infra-action  
   containers:
   - name: run-infra
-    image: gcr.io/k8s-skaffold/skaffold:latest
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
     command: ["/bin/sh"]
     args:
     - -c
     - |
-      skaffold deploy -p infra-only \
-        --status-check=false \
-        --kube-context=$(kubectl config current-context)
+      echo "Deploying infrastructure resources..."
+      # The manifests are already rendered by Cloud Deploy with parameters substituted
+      kubectl apply -f <(skaffold render -p infra-only) \
+        --wait=true \
+        --timeout=60s
+      echo "Infrastructure deployment complete"

--- a/skaffold-gateway-preview.yaml
+++ b/skaffold-gateway-preview.yaml
@@ -104,8 +104,8 @@ customActions:
     - -c
     - |
       echo "Deploying Config Connector resources (namespace + cert)..."
-      # Since we removed deployParameters from pipeline, we need to pass them explicitly
-      # Cloud Deploy will set these as environment variables from --deploy-parameters
+      # Specify the config file explicitly
       skaffold deploy -p config-connector \
+        --filename=skaffold-gateway-preview.yaml \
         --status-check=false
       echo "Config Connector deployment complete"


### PR DESCRIPTION
## Summary
- Consolidated three separate deployment stages (cert → infra → app) into one unified stage
- Improves Cloud Deploy UI by showing deployment as single cohesive unit
- Simplifies pipeline configuration and removes automation complexity

## Changes
- Combined `preview-gke-cert`, `preview-gke-infra`, and `preview-gke-app` targets into single `preview-gke` target
- Updated pipeline to use multiple Skaffold profiles (`cert-only`, `infra-only`, `app-only`) in one stage
- Removed 100+ lines of separate target and automation configurations
- Updated GitHub Actions workflow to deploy to the single target

## Benefits
- Cleaner Cloud Deploy console view - one stage instead of three disconnected blocks
- Simpler configuration - no automation rules needed between stages
- Same deployment behavior - still executes cert → infra → app in order

## Test plan
- [ ] Deploy a preview environment and verify all resources are created
- [ ] Check Cloud Deploy console shows single stage
- [ ] Verify cert, infra, and app components deploy in correct order
- [ ] Confirm preview URL is accessible

🤖 Generated with [Claude Code](https://claude.ai/code)