### PR TITLE
Simplify preview deployment with single target and preDeploy hook

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -42,7 +42,7 @@ jobs:
           --region=${{ env.GCP_REGION }} \
           --project=${{ env.GCP_PROJECT }} \
           --skaffold-file=skaffold-gateway-preview.yaml \
-          --to-target=preview-gke-cert \
+          --to-target=preview-gke \
           --deploy-parameters="DOMAIN=${DOMAIN},PREVIEW_NAME=${PREVIEW_NAME},NAMESPACE=${NAMESPACE},CERT_NAME=webapp-preview-cert-${PREVIEW_NAME},CERT_ENTRY_NAME=webapp-preview-entry-${PREVIEW_NAME},ROUTE_NAME=webapp-preview-route-${PREVIEW_NAME},CERT_DESCRIPTION=Certificate for ${DOMAIN},API_URL=https://api-${DOMAIN},ENV=preview,STAGE=preview,BOUNDARY=nonprod,TIER=preview,NAME_PREFIX=preview-,SERVICE_NAME=preview-webapp-service"
         
         echo "preview_url=https://${DOMAIN}" >> $GITHUB_OUTPUT

--- a/clouddeploy-preview.yaml
+++ b/clouddeploy-preview.yaml
@@ -1,5 +1,5 @@
 # Cloud Deploy Configuration for Preview Deployments
-# Supports dynamic domains like foo.webapp.u2i.dev
+# Single stage with kubectl preDeploy hook for proper sequencing
 
 apiVersion: deploy.cloud.google.com/v1
 kind: DeliveryPipeline
@@ -9,76 +9,26 @@ metadata:
     compliance: iso27001-soc2-gdpr
     team: webapp-team
     purpose: preview
-description: "Preview deployment pipeline with parameterized domains"
+description: "Preview deployment with Config Connector certificate provisioning"
 
 serialPipeline:
   stages:
-  # Stage 1: Create certificate and wait for it to be ready
-  - targetId: preview-gke-cert
-    profiles: ["cert-only"]
+  - targetId: preview-gke
+    profiles: ["preview-all"]
     strategy:
       standard:
         verify: false
-    deployParameters:
-    - values:
-        DOMAIN: ""
-        PREVIEW_NAME: ""
-        NAMESPACE: ""
-        CERT_NAME: ""
-        CERT_ENTRY_NAME: ""
-        CERT_DESCRIPTION: ""
-  
-  # Stage 2: Deploy infrastructure (service, configmap, routes)
-  - targetId: preview-gke-infra
-    profiles: ["infra-only"]
-    strategy:
-      standard:
-        verify: false
-    deployParameters:
-    - values:
-        DOMAIN: ""
-        PREVIEW_NAME: ""
-        NAMESPACE: ""
-        CERT_NAME: ""
-        CERT_ENTRY_NAME: ""
-        ROUTE_NAME: ""
-        API_URL: ""
-        ENV: ""
-        STAGE: ""
-        BOUNDARY: ""
-        TIER: ""
-        NAME_PREFIX: ""
-        SERVICE_NAME: ""
-  
-  # Stage 3: Deploy the application
-  - targetId: preview-gke-app
-    profiles: ["app-only"]
-    strategy:
-      standard:
-        verify: false
-    deployParameters:
-    - values:
-        DOMAIN: ""
-        PREVIEW_NAME: ""
-        NAMESPACE: ""
-        API_URL: ""
-        ENV: ""
-        STAGE: ""
-        BOUNDARY: ""
-        TIER: ""
-        NAME_PREFIX: ""
 
 ---
 apiVersion: deploy.cloud.google.com/v1
 kind: Target
 metadata:
-  name: preview-gke-cert
+  name: preview-gke
   labels:
     compliance: iso27001-soc2-gdpr
     environment: preview
     data-residency: eu
-    stage: certificate
-description: "Certificate provisioning stage"
+description: "Preview deployment target"
 
 gke:
   cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
@@ -87,79 +37,3 @@ executionConfigs:
 - usages: [RENDER, DEPLOY]
   serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
   artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
-
----
-apiVersion: deploy.cloud.google.com/v1
-kind: Target
-metadata:
-  name: preview-gke-infra
-  labels:
-    compliance: iso27001-soc2-gdpr
-    environment: preview
-    data-residency: eu
-    stage: infrastructure
-description: "Infrastructure deployment stage"
-
-gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
-  
-executionConfigs:
-- usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
-
----
-apiVersion: deploy.cloud.google.com/v1
-kind: Target
-metadata:
-  name: preview-gke-app
-  labels:
-    compliance: iso27001-soc2-gdpr
-    environment: preview
-    data-residency: eu
-    stage: application
-description: "Application deployment stage"
-
-gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
-  
-executionConfigs:
-- usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
-
----
-apiVersion: deploy.cloud.google.com/v1
-kind: Automation
-metadata:
-  name: webapp-preview-pipeline/promote-cert-to-infra
-  labels:
-    compliance: iso27001-soc2-gdpr
-description: "Auto-promote from cert to infra stage when cert is ready"
-suspended: false
-serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-selector:
-- target:
-    id: preview-gke-cert
-rules:
-- promoteReleaseRule:
-    id: promote-to-infra
-    toTargetId: preview-gke-infra
-
----
-apiVersion: deploy.cloud.google.com/v1
-kind: Automation
-metadata:
-  name: webapp-preview-pipeline/promote-infra-to-app
-  labels:
-    compliance: iso27001-soc2-gdpr
-description: "Auto-promote from infra to app stage when infra is ready"
-suspended: false
-serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-selector:
-- target:
-    id: preview-gke-infra
-rules:
-- promoteReleaseRule:
-    id: promote-to-app
-    toTargetId: preview-gke-app

--- a/skaffold-gateway-preview.yaml
+++ b/skaffold-gateway-preview.yaml
@@ -21,45 +21,45 @@ manifests:
 deploy:
   kubectl:
     flags:
-      apply: ["--wait=true"]
+      apply: ["--wait=true", "--server-side", "--timeout=600s"]
       global: ["--request-timeout=600s"]
   statusCheckDeadlineSeconds: 1200
+  hooks:
+    before:
+    - host:
+        command: ["sh", "-c"]
+        args:
+        - |
+          echo "=== Starting preDeploy hook for certificate provisioning ==="
+          
+          # 1️⃣ Create namespace and certificate
+          echo "Applying certificate resources..."
+          kubectl apply -k k8s-clean/overlays/preview-gateway-cert \
+            --wait=true --server-side --timeout=600s
+          
+          # 2️⃣ Wait for certificate to be ACTIVE
+          echo "Waiting for certificate to become ACTIVE..."
+          kubectl wait \
+            --for=jsonpath='{.status.state}'=ACTIVE \
+            --timeout=10m \
+            -n ${NAMESPACE} \
+            certificatemanagercertificates/${CERT_NAME}
+          
+          echo "Certificate is ACTIVE!"
+          
+          # 3️⃣ Apply infrastructure resources
+          echo "Applying infrastructure resources..."
+          kubectl apply -k k8s-clean/overlays/preview-gateway-infra \
+            --wait=true --server-side --timeout=300s
+          
+          echo "=== PreDeploy hook completed successfully ==="
 profiles:
-- name: cert-only
+# Single profile - app deployment only (cert and infra handled by preDeploy hook)
+- name: preview-all
   manifests:
     kustomize:
       paths:
-      - k8s-clean/overlays/preview-gateway-cert
-      buildArgs:
-      - --load-restrictor=LoadRestrictionsNone
-  deploy:
-    kubectl:
-      flags:
-        apply: ["--wait=true"]
-        global: ["--request-timeout=600s"]
-  
-- name: infra-only
-  manifests:
-    kustomize:
-      paths:
-      - k8s-clean/overlays/preview-gateway-infra
-      buildArgs:
-      - --load-restrictor=LoadRestrictionsNone
-  deploy:
-    kubectl:
-      flags:
-        apply: ["--wait=true"]
-        global: ["--request-timeout=60s"]
-
-- name: app-only
-  manifests:
-    kustomize:
-      paths:
+      # Only the application deployment - cert and infra are handled by the hook
       - k8s-clean/overlays/preview-gateway
       buildArgs:
       - --load-restrictor=LoadRestrictionsNone
-  deploy:
-    kubectl:
-      flags:
-        apply: ["--wait=true"]
-        global: ["--request-timeout=300s"]


### PR DESCRIPTION
## Summary
- Consolidate preview deployment into a single Cloud Deploy target
- Use kubectl preDeploy hook to ensure proper sequencing
- Keep Config Connector for certificate management

## Implementation

### Single Target Architecture
Instead of 3 separate targets (cert → infra → app), we now have:
- **One target**: `preview-gke` 
- **One profile**: `preview-all` (only deploys the app)
- **One preDeploy hook**: Handles cert and infra sequencing

### PreDeploy Hook Sequence
The hook executes before the main deployment:
1. **Certificate provisioning**: Apply Config Connector resources
2. **Wait for ACTIVE**: Ensure certificate is ready (up to 10 mins)
3. **Infrastructure setup**: Apply service, network policy, routes
4. **Main deployment**: Apply the application

### Benefits
- ✅ **Clean Cloud Deploy UI** - Single target, single stage
- ✅ **Proper sequencing** - Certificate guaranteed ACTIVE before use
- ✅ **Server-side apply** - Reliable field ownership tracking
- ✅ **Simpler config** - No multi-stage complexity or automations

## Changes
- Simplified `clouddeploy-preview.yaml` to single target
- Added mega preDeploy hook in `skaffold-gateway-preview.yaml`
- Updated GitHub Actions to deploy to single target
- Removed legacy profiles (kept only `preview-all`)

## Test Plan
- [ ] Deploy a new preview environment
- [ ] Verify certificate creation and ACTIVE status
- [ ] Confirm infrastructure resources deploy after cert
- [ ] Validate application deploys successfully
- [ ] Check Cloud Deploy UI shows single clean target

🤖 Generated with [Claude Code](https://claude.ai/code)