### PR TITLE
Update project references to new nonprod/prod naming convention

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -27,7 +27,7 @@ on:
         type: string
 
 env:
-  PROJECT_ID: u2i-tenant-webapp
+  PROJECT_ID: u2i-tenant-webapp-nonprod
   REGION: europe-west1
   PIPELINE: webapp-delivery-pipeline
 
@@ -52,7 +52,7 @@ jobs:
       uses: google-github-actions/auth@v1
       with:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: 'cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com'
+        service_account: 'cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com'
     
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
@@ -105,7 +105,7 @@ jobs:
           --region=$REGION \
           --delivery-pipeline=$PIPELINE \
           --source=. \
-          --gcs-source-staging-dir=gs://u2i-tenant-webapp-deploy-artifacts/source \
+          --gcs-source-staging-dir=gs://u2i-tenant-webapp-nonprod-deploy-artifacts/source \
           --labels="environment=nonproduction,compliance=iso27001-soc2-gdpr,deployed-by=github-actions"
         
         echo "✅ Created release: $RELEASE_NAME"
@@ -238,7 +238,7 @@ jobs:
             \`\`\`bash
             # After approval, run:
             gcloud deploy releases promote \\
-              --project=u2i-tenant-webapp \\
+              --project=u2i-tenant-webapp-nonprod \\
               --region=europe-west1 \\
               --delivery-pipeline=webapp-delivery-pipeline \\
               --release=${{ needs.deploy-nonprod.outputs.release-name }} \\
@@ -273,7 +273,7 @@ jobs:
       uses: google-github-actions/auth@v1
       with:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: 'cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com'
+        service_account: 'cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com'
     
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
@@ -288,7 +288,7 @@ jobs:
         # Verify non-prod is healthy
         gcloud container clusters get-credentials webapp-cluster \
           --location=$REGION \
-          --project=u2i-tenant-webapp
+          --project=u2i-tenant-webapp-nonprod
         
         if ! kubectl get pods -l app=webapp -n webapp-team --field-selector=status.phase=Running | grep -q webapp; then
           echo "❌ Non-production environment is not healthy"

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -11,7 +11,7 @@ on:
       - '!.github/workflows/cd-dev.yml'
 
 env:
-  PROJECT_ID: u2i-tenant-webapp
+  PROJECT_ID: u2i-tenant-webapp-nonprod
   REGION: europe-west1
   PIPELINE: webapp-pipeline
 
@@ -31,7 +31,7 @@ jobs:
       uses: google-github-actions/auth@v1
       with:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: 'cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com'
+        service_account: 'cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com'
     
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
@@ -67,7 +67,7 @@ jobs:
           --region=$REGION \
           --delivery-pipeline=$PIPELINE \
           --source=. \
-          --gcs-source-staging-dir=gs://u2i-tenant-webapp-deploy-artifacts/source \
+          --gcs-source-staging-dir=gs://u2i-tenant-webapp-nonprod-deploy-artifacts/source \
           --labels="stage=dev,trigger=push-to-main,git-sha=${GITHUB_SHA:0:7}" \
           --skaffold-file=skaffold-unified.yaml \
           --to-target=dev-gke

--- a/.github/workflows/cd-prod-promote.yml
+++ b/.github/workflows/cd-prod-promote.yml
@@ -26,7 +26,7 @@ on:
         type: string
 
 env:
-  PROJECT_ID: u2i-tenant-webapp
+  PROJECT_ID: u2i-tenant-webapp-nonprod
   REGION: europe-west1
   PIPELINE: webapp-staged-pipeline
 
@@ -49,7 +49,7 @@ jobs:
       uses: google-github-actions/auth@v1
       with:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: 'cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com'
+        service_account: 'cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com'
     
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1

--- a/.github/workflows/cd-promote.yml
+++ b/.github/workflows/cd-promote.yml
@@ -25,7 +25,7 @@ on:
         type: string
 
 env:
-  PROJECT_ID: u2i-tenant-webapp
+  PROJECT_ID: u2i-tenant-webapp-nonprod
   REGION: europe-west1
   PIPELINE: webapp-pipeline
 
@@ -64,7 +64,7 @@ jobs:
       uses: google-github-actions/auth@v1
       with:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: 'cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com'
+        service_account: 'cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com'
     
     - name: Set up Cloud SDK
       if: steps.validate.outputs.valid == 'true'
@@ -118,7 +118,7 @@ jobs:
       uses: google-github-actions/auth@v1
       with:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: 'cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com'
+        service_account: 'cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com'
     
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1

--- a/.github/workflows/cd-qa.yml
+++ b/.github/workflows/cd-qa.yml
@@ -16,7 +16,7 @@ on:
         type: string
 
 env:
-  PROJECT_ID: u2i-tenant-webapp
+  PROJECT_ID: u2i-tenant-webapp-nonprod
   REGION: europe-west1
   PIPELINE: webapp-pipeline
 
@@ -49,7 +49,7 @@ jobs:
       uses: google-github-actions/auth@v1
       with:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: 'cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com'
+        service_account: 'cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com'
     
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
@@ -88,7 +88,7 @@ jobs:
           --region=$REGION \
           --delivery-pipeline=$PIPELINE \
           --source=. \
-          --gcs-source-staging-dir=gs://u2i-tenant-webapp-deploy-artifacts/source \
+          --gcs-source-staging-dir=gs://u2i-tenant-webapp-nonprod-deploy-artifacts/source \
           --labels="stage=qa,version=${LABEL_TAG},trigger=${{ github.event_name }}" \
           --annotations="tag=${TAG},reason=${{ github.event.inputs.reason || 'Tag push' }}" \
           --skaffold-file=skaffold-unified.yaml \

--- a/.github/workflows/cd-status.yml
+++ b/.github/workflows/cd-status.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 * * * *'
 
 env:
-  PROJECT_ID: u2i-tenant-webapp
+  PROJECT_ID: u2i-tenant-webapp-nonprod
   REGION: europe-west1
   PIPELINE: webapp-pipeline
 
@@ -25,7 +25,7 @@ jobs:
       uses: google-github-actions/auth@v1
       with:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: 'cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com'
+        service_account: 'cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com'
     
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1

--- a/.github/workflows/ci-compliance.yml
+++ b/.github/workflows/ci-compliance.yml
@@ -11,7 +11,7 @@ on:
       - 'Dockerfile'
 
 env:
-  PROJECT_ID: u2i-tenant-webapp
+  PROJECT_ID: u2i-tenant-webapp-nonprod
   REGION: europe-west1
 
 jobs:

--- a/.github/workflows/cleanup-old-previews.yaml
+++ b/.github/workflows/cleanup-old-previews.yaml
@@ -12,7 +12,7 @@ on:
         default: '7'
 
 env:
-  GCP_PROJECT: u2i-tenant-webapp
+  GCP_PROJECT: u2i-tenant-webapp-nonprod
   GCP_REGION: europe-west1
 
 jobs:

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  GCP_PROJECT: u2i-tenant-webapp
+  GCP_PROJECT: u2i-tenant-webapp-nonprod
   GCP_REGION: europe-west1
   PIPELINE: webapp-dev-pipeline
 

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  GCP_PROJECT: u2i-tenant-webapp
+  GCP_PROJECT: u2i-tenant-webapp-nonprod
   GCP_REGION: europe-west1
   PIPELINE: webapp-preview-pipeline
 

--- a/.github/workflows/deploy-qa-prod.yaml
+++ b/.github/workflows/deploy-qa-prod.yaml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  GCP_PROJECT: u2i-tenant-webapp
+  GCP_PROJECT: u2i-tenant-webapp-nonprod
   GCP_REGION: europe-west1
   PIPELINE: webapp-qa-prod-pipeline
 

--- a/.github/workflows/production-promotion.yml
+++ b/.github/workflows/production-promotion.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
 
 env:
-  PROJECT_ID: u2i-tenant-webapp
+  PROJECT_ID: u2i-tenant-webapp-nonprod
   REGION: europe-west1
   PIPELINE: webapp-pipeline
 
@@ -107,7 +107,7 @@ jobs:
       uses: google-github-actions/auth@v1
       with:
         workload_identity_provider: 'projects/310843575960/locations/global/workloadIdentityPools/webapp-github-pool/providers/github'
-        service_account: 'cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com'
+        service_account: 'cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com'
     
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
@@ -136,7 +136,7 @@ jobs:
         # Get non-prod cluster credentials
         gcloud container clusters get-credentials webapp-cluster \
           --location=$REGION \
-          --project=u2i-tenant-webapp
+          --project=u2i-tenant-webapp-nonprod
         
         # Check if pods are healthy
         if ! kubectl get pods -l app=webapp -n webapp-team --field-selector=status.phase=Running | grep -q webapp; then
@@ -196,7 +196,7 @@ jobs:
       uses: google-github-actions/auth@v1
       with:
         workload_identity_provider: 'projects/310843575960/locations/global/workloadIdentityPools/webapp-github-pool/providers/github'
-        service_account: 'cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com'
+        service_account: 'cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com'
     
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This includes:
 ## 🔧 Getting Started
 
 ### Prerequisites
-- Access to `u2i-tenant-webapp` GCP project
+- Access to `u2i-tenant-webapp-nonprod` GCP project
 - Membership in `webapp-team@u2i.com` Google Group
 - GitHub repository access with proper branch protection
 
@@ -80,7 +80,7 @@ docker run -p 8080:8080 webapp
 
 # Deploy to non-production  
 gcloud deploy releases create dev-$(date +%Y%m%d-%H%M%S) \
-  --project=u2i-tenant-webapp \
+  --project=u2i-tenant-webapp-nonprod \
   --region=europe-west1 \
   --delivery-pipeline=webapp-delivery-pipeline \
   --source=.
@@ -90,7 +90,7 @@ gcloud deploy releases create dev-$(date +%Y%m%d-%H%M%S) \
 ```bash
 # Promote to production (requires approval)
 gcloud deploy releases promote \
-  --project=u2i-tenant-webapp \
+  --project=u2i-tenant-webapp-nonprod \
   --region=europe-west1 \
   --delivery-pipeline=webapp-delivery-pipeline \
   --release=RELEASE_NAME \

--- a/clouddeploy-3stage.yaml
+++ b/clouddeploy-3stage.yaml
@@ -92,11 +92,11 @@ metadata:
     stage: certificate
 requireApproval: false
 gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
+  cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
 executionConfigs:
 - usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
+  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
+  artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts
 
 ---
 apiVersion: deploy.cloud.google.com/v1
@@ -108,11 +108,11 @@ metadata:
     stage: infrastructure
 requireApproval: false
 gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
+  cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
 executionConfigs:
 - usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
+  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
+  artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts
 
 ---
 apiVersion: deploy.cloud.google.com/v1
@@ -124,11 +124,11 @@ metadata:
     stage: application
 requireApproval: false
 gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
+  cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
 executionConfigs:
 - usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
+  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
+  artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts
 
 ---
 # QA Targets
@@ -143,11 +143,11 @@ metadata:
     data-residency: eu
 requireApproval: false
 gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
+  cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
 executionConfigs:
 - usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
+  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
+  artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts
 
 ---
 apiVersion: deploy.cloud.google.com/v1
@@ -161,11 +161,11 @@ metadata:
     data-residency: eu
 requireApproval: false
 gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
+  cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
 executionConfigs:
 - usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
+  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
+  artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts
 
 ---
 apiVersion: deploy.cloud.google.com/v1
@@ -179,11 +179,11 @@ metadata:
     data-residency: eu
 requireApproval: false
 gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
+  cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
 executionConfigs:
 - usages: [RENDER, DEPLOY, VERIFY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
+  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
+  artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts
 
 ---
 # Production Targets
@@ -250,7 +250,7 @@ metadata:
     compliance: iso27001-soc2-gdpr
 description: "Auto-promote from cert to infra stage"
 suspended: false
-serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
+serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
 selector:
 - target:
     id: dev-cert
@@ -269,7 +269,7 @@ metadata:
     compliance: iso27001-soc2-gdpr
 description: "Auto-promote from infra to app stage"
 suspended: false
-serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
+serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
 selector:
 - target:
     id: dev-infra
@@ -289,7 +289,7 @@ metadata:
     compliance: iso27001-soc2-gdpr
 description: "Auto-promote from QA cert to infra stage"
 suspended: false
-serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
+serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
 selector:
 - target:
     id: qa-cert
@@ -308,7 +308,7 @@ metadata:
     compliance: iso27001-soc2-gdpr
 description: "Auto-promote from QA infra to app stage"
 suspended: false
-serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
+serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
 selector:
 - target:
     id: qa-infra

--- a/clouddeploy-preview.yaml
+++ b/clouddeploy-preview.yaml
@@ -31,9 +31,9 @@ metadata:
 description: "Preview deployment target"
 
 gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
+  cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
   
 executionConfigs:
 - usages: [RENDER, DEPLOY, PREDEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
+  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
+  artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts

--- a/clouddeploy-single-stage.yaml
+++ b/clouddeploy-single-stage.yaml
@@ -48,11 +48,11 @@ metadata:
     environment: dev
 requireApproval: false
 gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
+  cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
 executionConfigs:
 - usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
+  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
+  artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts
 
 ---
 # QA Target
@@ -66,11 +66,11 @@ metadata:
     data-residency: eu
 requireApproval: false
 gke:
-  cluster: projects/u2i-tenant-webapp/locations/europe-west1/clusters/webapp-cluster
+  cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
 executionConfigs:
 - usages: [RENDER, DEPLOY, VERIFY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-deploy-artifacts
+  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
+  artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts
 
 ---
 # Production Target

--- a/k8s-clean/base/deployment.yaml
+++ b/k8s-clean/base/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: webapp
-        image: europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images/webapp
+        image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-nonprod/webapp-images/webapp
         ports:
         - containerPort: 8080
           name: http

--- a/scripts/cleanup-preview-pr.sh
+++ b/scripts/cleanup-preview-pr.sh
@@ -13,7 +13,7 @@ fi
 
 PREVIEW_NAME="pr-${PR_NUMBER}"
 NAMESPACE="webapp-preview-${PREVIEW_NAME}"
-PROJECT="u2i-tenant-webapp"
+PROJECT="u2i-tenant-webapp-nonprod"
 
 echo "🧹 Cleaning up preview environment for PR #${PR_NUMBER}"
 echo ""

--- a/scripts/deploy-preview.sh
+++ b/scripts/deploy-preview.sh
@@ -22,7 +22,7 @@ echo "Namespace: ${NAMESPACE}"
 gcloud deploy releases create "preview-${PREVIEW_NAME}-$(date +%Y%m%d%H%M%S)" \
 	--delivery-pipeline=webapp-preview-pipeline \
 	--region=europe-west1 \
-	--project=u2i-tenant-webapp \
+	--project=u2i-tenant-webapp-nonprod \
 	--skaffold-file=skaffold-gateway-preview.yaml \
 	--deploy-parameters="DOMAIN=${DOMAIN},PREVIEW_NAME=${PREVIEW_NAME},NAMESPACE=${NAMESPACE},CERT_NAME=webapp-preview-cert-${PREVIEW_NAME},CERT_ENTRY_NAME=webapp-preview-entry-${PREVIEW_NAME},ROUTE_NAME=webapp-preview-route-${PREVIEW_NAME},CERT_DESCRIPTION=Certificate for ${DOMAIN},API_URL=https://api-${DOMAIN}" \
 	--to-target=preview-gke-cert

--- a/scripts/promote-to-prod.sh
+++ b/scripts/promote-to-prod.sh
@@ -26,7 +26,7 @@ gcloud deploy releases promote \
     --release="${RELEASE_NAME}" \
     --delivery-pipeline=webapp-qa-prod-pipeline \
     --region=europe-west1 \
-    --project=u2i-tenant-webapp \
+    --project=u2i-tenant-webapp-prod \
     --to-target=prod
 
 echo ""

--- a/scripts/setup-approvers.sh
+++ b/scripts/setup-approvers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Script to set up Cloud Deploy approval permissions
 
-PROJECT_ID="u2i-tenant-webapp"
+PROJECT_ID="u2i-tenant-webapp-nonprod"
 REGION="europe-west1"
 PIPELINE="webapp-pipeline"
 

--- a/scripts/setup-github-wif.sh
+++ b/scripts/setup-github-wif.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # Configuration
-PROJECT_ID="u2i-tenant-webapp"
+PROJECT_ID="u2i-tenant-webapp-nonprod"
 REPO="u2i/webapp-team-app"  # Update this to your actual repo
 SERVICE_ACCOUNT_NAME="github-actions-sa"
 WORKLOAD_IDENTITY_POOL="github-actions-pool"

--- a/scripts/test-developer-permissions.sh
+++ b/scripts/test-developer-permissions.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-PROJECT_ID="u2i-tenant-webapp"
+PROJECT_ID="u2i-tenant-webapp-nonprod"
 REGION="europe-west1"
 PIPELINE="webapp-pipeline"
 TIMESTAMP=$(date +%Y%m%d%H%M%S)
@@ -70,7 +70,7 @@ CREATE_OUTPUT=$(gcloud deploy releases create $TEST_RELEASE \
     --region=$REGION \
     --delivery-pipeline=$PIPELINE \
     --skaffold-file=skaffold-unified.yaml \
-    --images=webapp=europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images/webapp:v5 2>&1)
+    --images=webapp=europe-west1-docker.pkg.dev/u2i-tenant-webapp-nonprod/webapp-images/webapp:v5 2>&1)
 CREATE_RESULT=$?
 check_result $CREATE_RESULT "Can create releases" "$CREATE_OUTPUT"
 
@@ -167,7 +167,7 @@ check_result $VIEW_RESULT "Can view all rollouts" "$VIEW_OUTPUT"
 # Test 9: Check artifact upload permissions
 echo "9️⃣ Testing artifact upload permissions..."
 echo "test-content" > /tmp/test-artifact.txt
-UPLOAD_OUTPUT=$(gsutil cp /tmp/test-artifact.txt gs://u2i-tenant-webapp-deploy-artifacts/test/test-${TIMESTAMP}.txt 2>&1)
+UPLOAD_OUTPUT=$(gsutil cp /tmp/test-artifact.txt gs://u2i-tenant-webapp-nonprod-deploy-artifacts/test/test-${TIMESTAMP}.txt 2>&1)
 UPLOAD_RESULT=$?
 check_result $UPLOAD_RESULT "Can upload to deployment artifacts bucket" "$UPLOAD_OUTPUT"
 rm -f /tmp/test-artifact.txt
@@ -175,7 +175,7 @@ rm -f /tmp/test-artifact.txt
 # Test 10: Check Artifact Registry access
 echo "🔟 Testing Artifact Registry access..."
 AR_OUTPUT=$(gcloud artifacts docker images list \
-    europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images \
+    europe-west1-docker.pkg.dev/u2i-tenant-webapp-nonprod/webapp-images \
     --project=$PROJECT_ID \
     --limit=1 2>&1)
 AR_RESULT=$?

--- a/scripts/test-preview-deployment.sh
+++ b/scripts/test-preview-deployment.sh
@@ -18,7 +18,7 @@ echo ""
 gcloud deploy releases create "${RELEASE_NAME}" \
   --delivery-pipeline=webapp-preview-pipeline \
   --region=europe-west1 \
-  --project=u2i-tenant-webapp \
+  --project=u2i-tenant-webapp-nonprod \
   --skaffold-file=skaffold-gateway-preview.yaml \
   --to-target=preview-gke-cert \
   --deploy-parameters="DOMAIN=${DOMAIN},PREVIEW_NAME=${PREVIEW_NAME},NAMESPACE=${NAMESPACE},CERT_NAME=webapp-preview-cert-${PREVIEW_NAME},CERT_ENTRY_NAME=webapp-preview-entry-${PREVIEW_NAME},ROUTE_NAME=webapp-preview-route-${PREVIEW_NAME},CERT_DESCRIPTION=Certificate for ${DOMAIN},API_URL=https://api-${DOMAIN}"

--- a/skaffold-3stage.yaml
+++ b/skaffold-3stage.yaml
@@ -4,11 +4,11 @@ metadata:
   name: webapp-3stage-deployment
 build:
   artifacts:
-  - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images/webapp
+  - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-nonprod/webapp-images/webapp
     docker:
       dockerfile: Dockerfile
   googleCloudBuild:
-    projectId: u2i-tenant-webapp
+    projectId: u2i-tenant-webapp-nonprod
     region: europe-west1
   tagPolicy:
     gitCommit:

--- a/skaffold-gateway-preview.yaml
+++ b/skaffold-gateway-preview.yaml
@@ -17,11 +17,11 @@ metadata:
   name: webapp-preview-deployment
 build:
   artifacts:
-  - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images/webapp
+  - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-nonprod/webapp-images/webapp
     docker:
       dockerfile: Dockerfile
   googleCloudBuild:
-    projectId: u2i-tenant-webapp
+    projectId: u2i-tenant-webapp-nonprod
     region: europe-west1
   tagPolicy:
     sha256: {}

--- a/skaffold-single-stage.yaml
+++ b/skaffold-single-stage.yaml
@@ -17,11 +17,11 @@ metadata:
   name: webapp-deployment
 build:
   artifacts:
-  - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp/webapp-images/webapp
+  - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-nonprod/webapp-images/webapp
     docker:
       dockerfile: Dockerfile
   googleCloudBuild:
-    projectId: u2i-tenant-webapp
+    projectId: u2i-tenant-webapp-nonprod
     region: europe-west1
   tagPolicy:
     gitCommit:


### PR DESCRIPTION
## Summary
This PR updates all project references to align with the new infrastructure setup where non-prod and prod environments are in separate GCP projects.

## Changes Made

### Project Reference Updates
- ✅ Updated all non-prod references from `u2i-tenant-webapp` to `u2i-tenant-webapp-nonprod`
- ✅ Kept production references as `u2i-tenant-webapp-prod`
- ✅ Updated service accounts, buckets, and artifact registry paths

### Files Modified
1. **Cloud Deploy Configurations** - Updated all pipeline configurations
2. **Skaffold Configurations** - Updated build project and image references  
3. **Kubernetes Manifests** - Updated container image references
4. **Shell Scripts** - Updated project IDs and resource references
5. **GitHub Actions Workflows** - Updated environment variables and credentials
6. **Documentation** - Updated README with correct project names

### Infrastructure Alignment
These changes align with the new fleet management structure where:
- Non-prod cluster is registered to `u2i-platform-nonprod` fleet
- Infrastructure follows compliance requirements for environment separation
- Proper isolation between non-prod and prod environments

## Testing Checklist
- [ ] Verify Cloud Deploy pipelines can create releases
- [ ] Test deployments to dev environment
- [ ] Validate image builds in correct artifact registry
- [ ] Confirm GitHub Actions workflows authenticate correctly
- [ ] Test preview deployments work with new project

## Related Infrastructure Changes
This follows the infrastructure migration where the webapp-nonprod cluster was recreated and registered to the platform fleet management system.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>