### PR TITLE
Align dev deployment with preview approach

### DIFF
--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -1,6 +1,7 @@
 steps:
 # Build the Docker image
 - name: 'gcr.io/cloud-builders/docker'
+  id: 'build-image'
   args: [
     'build',
     '-t', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp:dev-${COMMIT_SHA}',
@@ -10,100 +11,34 @@ steps:
 
 # Push the Docker image
 - name: 'gcr.io/cloud-builders/docker'
+  id: 'push-image'
   args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp']
 
 # Deploy using Cloud Deploy
 - name: 'google/cloud-sdk:alpine'
+  id: 'deploy-dev'
   entrypoint: 'bash'
-  args:
-  - '-c'
-  - |
-    # Create Cloud Deploy release for dev
-    gcloud deploy releases create "dev-${SHORT_SHA}" \
-      --delivery-pipeline=webapp-dev-pipeline \
-      --region=${_REGION} \
-      --project=${_PROJECT_ID} \
-      --images="webapp=${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp:dev-${COMMIT_SHA}" \
-      --to-target=dev-gke \
-      --skaffold-file=skaffold-single-stage.yaml \
-      --deploy-parameters="NAMESPACE=webapp-dev,ENV=dev,API_URL=https://api-dev.webapp.u2i.dev,STAGE=dev,BOUNDARY=nonprod,TIER=standard,NAME_PREFIX=dev-,DOMAIN=dev.webapp.u2i.dev,ROUTE_NAME=webapp-dev-route,SERVICE_NAME=webapp-service,CERT_NAME=webapp-dev-cert,CERT_ENTRY_NAME=webapp-dev-entry,CERT_DESCRIPTION=Certificate for dev.webapp.u2i.dev"
-    
-    echo "✅ Dev deployment initiated: https://dev.webapp.u2i.dev"
+  args: ['scripts/deploy-dev.sh']
+  env:
+  - 'PROJECT_ID=${_PROJECT_ID}'
+  - 'REGION=${_REGION}'
+  - 'COMMIT_SHA=$COMMIT_SHA'
+  - 'SHORT_SHA=$SHORT_SHA'
 
 # Send Slack notification
-- name: 'google/cloud-sdk:alpine'
-  entrypoint: 'bash'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
+  id: 'slack-notification'
+  entrypoint: 'sh'
   args:
   - '-c'
   - |
-    COMMIT_SHA=${COMMIT_SHA:0:7}
-    COMMIT_MESSAGE=$(git log -1 --pretty=%s)
-    AUTHOR=$(git log -1 --pretty=%an)
-    DEV_URL="https://dev.webapp.u2i.dev"
-    BUILD_URL="https://console.cloud.google.com/cloud-build/builds;region=${_REGION}/${BUILD_ID}?project=${_PROJECT_ID}"
-    
-    # Get Slack token
-    SLACK_TOKEN=$(gcloud secrets versions access latest --secret=slack-bot-token --project=u2i-security)
-    
-    if [ -n "${SLACK_TOKEN}" ]; then
-      curl -X POST https://slack.com/api/chat.postMessage \
-        -H "Authorization: Bearer ${SLACK_TOKEN}" \
-        -H "Content-Type: application/json" \
-        -d '{
-          "channel": "#webapp-deployments",
-          "blocks": [
-            {
-              "type": "header",
-              "text": {
-                "type": "plain_text",
-                "text": "🚀 Dev Deployment Complete"
-              }
-            },
-            {
-              "type": "section",
-              "fields": [
-                {
-                  "type": "mrkdwn",
-                  "text": "*Environment:*\nDev"
-                },
-                {
-                  "type": "mrkdwn",
-                  "text": "*Commit:*\n`'${COMMIT_SHA}'`"
-                },
-                {
-                  "type": "mrkdwn",
-                  "text": "*Author:*\n'${AUTHOR}'"
-                },
-                {
-                  "type": "mrkdwn",
-                  "text": "*Message:*\n'${COMMIT_MESSAGE}'"
-                }
-              ]
-            },
-            {
-              "type": "actions",
-              "elements": [
-                {
-                  "type": "button",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "View Application"
-                  },
-                  "url": "'${DEV_URL}'"
-                },
-                {
-                  "type": "button",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "View Build"
-                  },
-                  "url": "'${BUILD_URL}'"
-                }
-              ]
-            }
-          ]
-        }'
-    fi
+    apk add --no-cache jq
+    bash scripts/slack-notification.sh
+  env:
+  - 'PROJECT_ID=${_PROJECT_ID}'
+  - 'REGION=${_REGION}'
+  - 'COMMIT_SHA=$COMMIT_SHA'
+  - 'BUILD_ID=$BUILD_ID'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/clouddeploy-dev.yaml
+++ b/clouddeploy-dev.yaml
@@ -14,7 +14,7 @@ description: "Dev deployment pipeline with single stage"
 serialPipeline:
   stages:
   - targetId: dev-gke
-    profiles: ["dev-all"]
+    profiles: ["dev"]
     strategy:
       standard:
         verify: false

--- a/clouddeploy-dev.yaml
+++ b/clouddeploy-dev.yaml
@@ -1,0 +1,39 @@
+# Cloud Deploy Configuration for Dev Environment
+# Single stage deployment with kubectl for proper sequencing
+
+apiVersion: deploy.cloud.google.com/v1
+kind: DeliveryPipeline
+metadata:
+  name: webapp-dev-pipeline
+  labels:
+    compliance: iso27001-soc2-gdpr
+    team: webapp-team
+    purpose: development
+description: "Dev deployment pipeline with single stage"
+
+serialPipeline:
+  stages:
+  - targetId: dev-gke
+    profiles: ["dev-all"]
+    strategy:
+      standard:
+        verify: false
+
+---
+apiVersion: deploy.cloud.google.com/v1
+kind: Target
+metadata:
+  name: dev-gke
+  labels:
+    compliance: iso27001-soc2-gdpr
+    environment: dev
+    data-residency: eu
+description: "Dev deployment target"
+
+gke:
+  cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
+  
+executionConfigs:
+- usages: [RENDER, DEPLOY]
+  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
+  artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -e
+
+echo "=== Starting deploy-dev.sh ==="
+
+# Check required Cloud Build variables
+MISSING_VARS=""
+if [ -z "$COMMIT_SHA" ]; then
+  MISSING_VARS="${MISSING_VARS}COMMIT_SHA "
+fi
+if [ -z "$SHORT_SHA" ]; then
+  MISSING_VARS="${MISSING_VARS}SHORT_SHA "
+fi
+
+if [ -n "$MISSING_VARS" ]; then
+  echo "ERROR: Required Cloud Build variables not set: $MISSING_VARS"
+  exit 1
+fi
+
+# Check required environment variables
+MISSING_ENV=""
+if [ -z "$PROJECT_ID" ]; then
+  MISSING_ENV="${MISSING_ENV}PROJECT_ID "
+fi
+if [ -z "$REGION" ]; then
+  MISSING_ENV="${MISSING_ENV}REGION "
+fi
+
+if [ -n "$MISSING_ENV" ]; then
+  echo "ERROR: Required environment variables not set: $MISSING_ENV"
+  exit 1
+fi
+
+# Dev deployment parameters
+NAMESPACE="webapp-dev"
+ENV="dev"
+API_URL="https://api-dev.webapp.u2i.dev"
+STAGE="dev"
+BOUNDARY="nonprod"
+TIER="standard"
+NAME_PREFIX="dev-"
+DOMAIN="dev.webapp.u2i.dev"
+ROUTE_NAME="webapp-dev-route"
+SERVICE_NAME="webapp-service"
+CERT_NAME="webapp-dev-cert"
+CERT_ENTRY_NAME="webapp-dev-entry"
+CERT_DESCRIPTION="Certificate for dev.webapp.u2i.dev"
+
+# Create Cloud Deploy release for dev
+echo "Creating Cloud Deploy release for dev environment..."
+gcloud deploy releases create "dev-${SHORT_SHA}" \
+  --delivery-pipeline=webapp-dev-pipeline \
+  --region=${REGION} \
+  --project=${PROJECT_ID} \
+  --images="${REGION}-docker.pkg.dev/${PROJECT_ID}/webapp-images/webapp=${REGION}-docker.pkg.dev/${PROJECT_ID}/webapp-images/webapp:dev-${COMMIT_SHA}" \
+  --to-target=dev-gke \
+  --skaffold-file=skaffold-dev-deploy.yaml \
+  --deploy-parameters="NAMESPACE=${NAMESPACE},ENV=${ENV},API_URL=${API_URL},STAGE=${STAGE},BOUNDARY=${BOUNDARY},TIER=${TIER},NAME_PREFIX=${NAME_PREFIX},DOMAIN=${DOMAIN},ROUTE_NAME=${ROUTE_NAME},SERVICE_NAME=${SERVICE_NAME},CERT_NAME=${CERT_NAME},CERT_ENTRY_NAME=${CERT_ENTRY_NAME},CERT_DESCRIPTION=${CERT_DESCRIPTION}" \
+  --impersonate-service-account=cloud-deploy-sa@${PROJECT_ID}.iam.gserviceaccount.com
+
+echo "✅ Dev deployment initiated: https://${DOMAIN}"

--- a/scripts/slack-notification.sh
+++ b/scripts/slack-notification.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -e
+
+echo "=== Sending Slack notification ==="
+
+# Check required variables
+if [ -z "$COMMIT_SHA" ] || [ -z "$BUILD_ID" ] || [ -z "$PROJECT_ID" ] || [ -z "$REGION" ]; then
+  echo "ERROR: Missing required variables for Slack notification"
+  exit 1
+fi
+
+# Extract commit information
+COMMIT_SHA_SHORT=${COMMIT_SHA:0:7}
+COMMIT_MESSAGE=$(git log -1 --pretty=%s)
+AUTHOR=$(git log -1 --pretty=%an)
+DEV_URL="https://dev.webapp.u2i.dev"
+BUILD_URL="https://console.cloud.google.com/cloud-build/builds;region=${REGION}/${BUILD_ID}?project=${PROJECT_ID}"
+
+# Get Slack token from Secret Manager
+echo "Fetching Slack token..."
+SLACK_TOKEN=$(gcloud secrets versions access latest --secret=slack-bot-token --project=u2i-security 2>/dev/null || echo "")
+
+if [ -z "$SLACK_TOKEN" ]; then
+  echo "WARNING: Could not fetch Slack token, skipping notification"
+  exit 0
+fi
+
+# Send Slack notification
+echo "Posting to Slack channel #webapp-deployments..."
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer ${SLACK_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "#webapp-deployments",
+    "blocks": [
+      {
+        "type": "header",
+        "text": {
+          "type": "plain_text",
+          "text": "🚀 Dev Deployment Complete"
+        }
+      },
+      {
+        "type": "section",
+        "fields": [
+          {
+            "type": "mrkdwn",
+            "text": "*Environment:*\nDev"
+          },
+          {
+            "type": "mrkdwn",
+            "text": "*Commit:*\n`'"${COMMIT_SHA_SHORT}"'`"
+          },
+          {
+            "type": "mrkdwn",
+            "text": "*Author:*\n'"${AUTHOR}"'"
+          },
+          {
+            "type": "mrkdwn",
+            "text": "*Message:*\n'"${COMMIT_MESSAGE}"'"
+          }
+        ]
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "View Application"
+            },
+            "url": "'"${DEV_URL}"'"
+          },
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "View Build"
+            },
+            "url": "'"${BUILD_URL}"'"
+          }
+        ]
+      }
+    ]
+  }')
+
+HTTP_STATUS=$(echo "$RESPONSE" | tail -n 1)
+RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_STATUS" = "200" ]; then
+  # Check if Slack API returned ok
+  OK_STATUS=$(echo "$RESPONSE_BODY" | jq -r '.ok' 2>/dev/null || echo "false")
+  if [ "$OK_STATUS" = "true" ]; then
+    echo "✅ Slack notification sent successfully"
+  else
+    echo "WARNING: Slack API returned error"
+    echo "Response: $RESPONSE_BODY"
+  fi
+else
+  echo "WARNING: Failed to send Slack notification"
+  echo "HTTP Status: $HTTP_STATUS"
+fi
+
+# Don't fail the build for notification issues
+exit 0

--- a/skaffold-dev-deploy.yaml
+++ b/skaffold-dev-deploy.yaml
@@ -30,4 +30,4 @@ deploy:
     flags:
       apply: ["--server-side", "--force-conflicts"]
 profiles:
-- name: dev-all
+- name: dev

--- a/skaffold-dev-deploy.yaml
+++ b/skaffold-dev-deploy.yaml
@@ -1,0 +1,33 @@
+apiVersion: skaffold/v4beta13
+kind: Config
+metadata:
+  name: webapp-namespace
+# Namespace module - creates namespace for dev environment
+manifests:
+  rawYaml:
+  - k8s-clean/namespace/namespace.yaml
+deploy:
+  kubectl:
+    flags:
+      apply: ["--server-side", "--force-conflicts"]
+---
+apiVersion: skaffold/v4beta13
+kind: Config
+metadata:
+  name: webapp-dev-deployment
+# Build section required for image substitution, but build is skipped when image is provided
+build:
+  artifacts:
+  - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-nonprod/webapp-images/webapp
+manifests:
+  kustomize:
+    paths:
+    - k8s-clean/overlays/dev-gateway
+    buildArgs:
+    - --load-restrictor=LoadRestrictionsNone
+deploy:
+  kubectl:
+    flags:
+      apply: ["--server-side", "--force-conflicts"]
+profiles:
+- name: dev-all


### PR DESCRIPTION
## Summary
Refactor the dev deployment configuration to follow the same patterns as the preview deployment for consistency and maintainability.

## Changes
- Extract deployment logic from inline cloudbuild.yaml to dedicated scripts:
  - `scripts/deploy-dev.sh`: Handles Cloud Deploy release creation
  - `scripts/slack-notification.sh`: Sends deployment notifications to Slack
- Create dedicated configuration files:
  - `skaffold-dev-deploy.yaml`: Dev-specific Skaffold configuration
  - `clouddeploy-dev.yaml`: Dev-specific Cloud Deploy pipeline
- Use same patterns as preview deployment:
  - External scripts to avoid substitution variable issues
  - Explicit environment variable passing
  - Proper error handling and validation
  - Consistent file naming and organization

## Benefits
- Consistency across deployment environments
- Easier to maintain and debug
- Reusable scripts for notifications
- Clear separation of concerns

## Fix included
- Fixed skaffold profile name from 'dev-all' to 'dev' to match Cloud Deploy expectations