### PR TITLE
fix: remove service account impersonation from QA deploy script

### DIFF
--- a/clouddeploy-qa-prod.yaml
+++ b/clouddeploy-qa-prod.yaml
@@ -38,15 +38,14 @@ metadata:
     environment: qa
     data-residency: eu
 description: "QA deployment target"
-
-requireApproval: false
-gke:
-  cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
-  
-executionConfigs:
-- usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts
+spec:
+  requireApproval: false
+  gke:
+    cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
+  executionConfigs:
+  - usages: [RENDER, DEPLOY]
+    serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
+    artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts
 
 ---
 # Production Target
@@ -59,12 +58,11 @@ metadata:
     environment: prod
     data-residency: eu
 description: "Production deployment target"
-
-requireApproval: true
-gke:
-  cluster: projects/u2i-tenant-webapp-prod/locations/europe-west1/clusters/webapp-cluster-prod
-  
-executionConfigs:
-- usages: [RENDER, DEPLOY]
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-prod.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-prod-deploy-artifacts
+spec:
+  requireApproval: true
+  gke:
+    cluster: projects/u2i-tenant-webapp-prod/locations/europe-west1/clusters/webapp-cluster-prod
+  executionConfigs:
+  - usages: [RENDER, DEPLOY]
+    serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-prod.iam.gserviceaccount.com
+    artifactStorage: gs://u2i-tenant-webapp-prod-deploy-artifacts

--- a/scripts/deploy-qa.sh
+++ b/scripts/deploy-qa.sh
@@ -48,10 +48,7 @@ CERT_DESCRIPTION="Certificate for qa.webapp.u2i.dev"
 
 # Create Cloud Deploy release for QA
 echo "Creating Cloud Deploy release for QA environment..."
-# For the QA/Prod pipeline that spans multiple projects, we need to impersonate
-# cloud-deploy-sa@prod which has permissions across both projects.
-# This avoids the ACTAS_PERMISSION_DENIED error when Cloud Deploy validates
-# permissions for all stages in the pipeline.
+# The Cloud Build trigger already runs as webapp-ci which has the necessary permissions
 gcloud deploy releases create "qa-${SHORT_SHA}" \
   --delivery-pipeline=webapp-qa-prod-pipeline \
   --region=${REGION} \
@@ -59,8 +56,7 @@ gcloud deploy releases create "qa-${SHORT_SHA}" \
   --images="${REGION}-docker.pkg.dev/${PROJECT_ID}/webapp-images/webapp=${REGION}-docker.pkg.dev/${PROJECT_ID}/webapp-images/webapp:qa-${COMMIT_SHA}" \
   --to-target=qa-gke \
   --skaffold-file=skaffold-qa-deploy.yaml \
-  --deploy-parameters="NAMESPACE=${NAMESPACE},ENV=${ENV},API_URL=${API_URL},STAGE=${STAGE},BOUNDARY=${BOUNDARY},TIER=${TIER},NAME_PREFIX=${NAME_PREFIX},DOMAIN=${DOMAIN},ROUTE_NAME=${ROUTE_NAME},SERVICE_NAME=${SERVICE_NAME},CERT_NAME=${CERT_NAME},CERT_ENTRY_NAME=${CERT_ENTRY_NAME},CERT_DESCRIPTION=${CERT_DESCRIPTION}" \
-  --impersonate-service-account=cloud-deploy-sa@u2i-tenant-webapp-prod.iam.gserviceaccount.com
+  --deploy-parameters="NAMESPACE=${NAMESPACE},ENV=${ENV},API_URL=${API_URL},STAGE=${STAGE},BOUNDARY=${BOUNDARY},TIER=${TIER},NAME_PREFIX=${NAME_PREFIX},DOMAIN=${DOMAIN},ROUTE_NAME=${ROUTE_NAME},SERVICE_NAME=${SERVICE_NAME},CERT_NAME=${CERT_NAME},CERT_ENTRY_NAME=${CERT_ENTRY_NAME},CERT_DESCRIPTION=${CERT_DESCRIPTION}"
 
 echo "✅ QA deployment initiated: https://${DOMAIN}"
 echo "ℹ️  After QA validation, the release can be promoted to production with approval"


### PR DESCRIPTION
## Summary
- Remove the --impersonate-service-account flag from QA deploy script
- Fix Cloud Deploy target YAML structure

## Problem
1. We were getting permission errors because of unnecessary impersonation
2. The Cloud Deploy targets had invalid YAML structure (missing spec: blocks)

## Solution
1. Remove impersonation - the Cloud Build trigger already runs as webapp-ci which has all necessary permissions
2. Fix target YAML - nest requireApproval, gke, and executionConfigs under spec:

With proper executionConfigs in each target, Cloud Deploy will automatically use the correct service account for each stage without manual impersonation.

## Test Plan
1. Merge this PR
2. Apply the updated Cloud Deploy configuration
3. Create a new QA deployment tag
4. Verify the deployment succeeds without ActAs errors