### PR TITLE
Fix Cloud Deploy YAML structure

### DIFF
--- a/clouddeploy-qa-prod.yaml
+++ b/clouddeploy-qa-prod.yaml
@@ -34,19 +34,15 @@ metadata:
     environment: qa
     data-residency: eu
 description: QA deployment target
-targetId: qa-gke
 gke:
   cluster: projects/u2i-tenant-webapp-nonprod/locations/europe-west1/clusters/webapp-cluster
 executionConfigs:
-- usages:
-  - RENDER
-  - DEPLOY
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts
-  executionTimeout: 3600s
-  defaultPool:
+  - usages:
+      - RENDER
+      - DEPLOY
     serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-nonprod.iam.gserviceaccount.com
     artifactStorage: gs://u2i-tenant-webapp-nonprod-deploy-artifacts
+    executionTimeout: 3600s
 
 ---
 # Production Target
@@ -59,17 +55,13 @@ metadata:
     environment: prod
     data-residency: eu
 description: Production deployment target
-targetId: prod-gke
 requireApproval: true
 gke:
   cluster: projects/u2i-tenant-webapp-prod/locations/europe-west1/clusters/webapp-cluster-prod
 executionConfigs:
-- usages:
-  - RENDER
-  - DEPLOY
-  serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-prod.iam.gserviceaccount.com
-  artifactStorage: gs://u2i-tenant-webapp-prod-deploy-artifacts
-  executionTimeout: 3600s
-  defaultPool:
+  - usages:
+      - RENDER
+      - DEPLOY
     serviceAccount: cloud-deploy-sa@u2i-tenant-webapp-prod.iam.gserviceaccount.com
     artifactStorage: gs://u2i-tenant-webapp-prod-deploy-artifacts
+    executionTimeout: 3600s


### PR DESCRIPTION
## Summary
- Remove redundant targetId fields
- Remove defaultPool sections  
- Fix usages indentation to proper YAML list format

## Context
Based on the actual Cloud Deploy API structure from gcloud exports, these changes align our YAML with what Cloud Deploy expects.

## Changes
1. **Removed targetId**: The target name in metadata is sufficient
2. **Removed defaultPool**: This was redundant with the main executionConfigs
3. **Fixed indentation**: usages should be indented as a YAML list under executionConfigs

## Testing
These changes match the structure that gcloud deploy exports, ensuring compatibility with the Cloud Deploy API.