### PR TITLE
Fix multi-stage pipeline skaffold configuration

### DIFF
--- a/scripts/deploy-qa.sh
+++ b/scripts/deploy-qa.sh
@@ -68,7 +68,7 @@ gcloud deploy releases create "qa-${SHORT_SHA}" \
   --project=${PROJECT_ID} \
   --images="${REGION}-docker.pkg.dev/${PROJECT_ID}/webapp-images/webapp=${REGION}-docker.pkg.dev/${PROJECT_ID}/webapp-images/webapp:qa-${COMMIT_SHA}" \
   --to-target=qa-gke \
-  --skaffold-file=skaffold-qa-deploy.yaml \
+  --skaffold-file=skaffold-qa-prod.yaml \
   --deploy-parameters="NAMESPACE=${NAMESPACE},ENV=${ENV},API_URL=${API_URL},STAGE=${STAGE},BOUNDARY=${BOUNDARY},TIER=${TIER},NAME_PREFIX=${NAME_PREFIX},DOMAIN=${DOMAIN},ROUTE_NAME=${ROUTE_NAME},SERVICE_NAME=${SERVICE_NAME},CERT_NAME=${CERT_NAME},CERT_ENTRY_NAME=${CERT_ENTRY_NAME},CERT_DESCRIPTION=${CERT_DESCRIPTION}"
 
 echo "✅ QA deployment initiated: https://${DOMAIN}"

--- a/skaffold-qa-prod.yaml
+++ b/skaffold-qa-prod.yaml
@@ -1,0 +1,81 @@
+apiVersion: skaffold/v4beta13
+kind: Config
+metadata:
+  name: webapp-qa-prod-deployment
+# Build section required for image substitution, but build is skipped when image is provided
+build:
+  artifacts:
+  - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-nonprod/webapp-images/webapp
+    # This image is used across both QA and Prod deployments
+manifests:
+  kustomize:
+    paths:
+    - k8s-clean/overlays/qa-gateway  # Default to QA
+    buildArgs:
+    - --load-restrictor=LoadRestrictionsNone
+deploy:
+  kubectl:
+    flags:
+      apply: ["--server-side", "--force-conflicts"]
+profiles:
+# QA Profile
+- name: qa
+  manifests:
+    kustomize:
+      paths:
+      - k8s-clean/overlays/qa-gateway
+      buildArgs:
+      - --load-restrictor=LoadRestrictionsNone
+  # For QA, we deploy the namespace from the same project
+  requires:
+  - configs:
+    - webapp-namespace-qa
+
+# Production Profile
+- name: prod
+  build:
+    artifacts:
+    - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-prod/webapp-images/webapp
+      # For prod, we use the prod artifact registry
+  manifests:
+    kustomize:
+      paths:
+      - k8s-clean/overlays/production-gateway
+      buildArgs:
+      - --load-restrictor=LoadRestrictionsNone
+  # For prod, we deploy the namespace from the same project
+  requires:
+  - configs:
+    - webapp-namespace-prod
+---
+# QA Namespace Configuration
+apiVersion: skaffold/v4beta13
+kind: Config
+metadata:
+  name: webapp-namespace-qa
+manifests:
+  rawYaml:
+  - k8s-clean/namespace/namespace.yaml
+deploy:
+  kubectl:
+    flags:
+      apply: ["--server-side", "--force-conflicts"]
+profiles:
+- name: qa
+  # QA namespace configuration
+---
+# Production Namespace Configuration
+apiVersion: skaffold/v4beta13
+kind: Config
+metadata:
+  name: webapp-namespace-prod
+manifests:
+  rawYaml:
+  - k8s-clean/namespace/namespace.yaml
+deploy:
+  kubectl:
+    flags:
+      apply: ["--server-side", "--force-conflicts"]
+profiles:
+- name: prod
+  # Production namespace configuration


### PR DESCRIPTION
## Summary
- Create unified skaffold-qa-prod.yaml with both qa and prod profiles
- Update deploy script to use the unified skaffold file

## Context
The Cloud Deploy rendering was failing for the prod stage with error:
```
profile selection ["prod"] did not match those defined in any configurations
```

This happened because the QA/Prod pipeline needs to render manifests for both stages, but we were using skaffold-qa-deploy.yaml which only had a qa profile.

## Fix
Created a unified skaffold file that includes:
- **qa** profile: Uses qa-gateway overlay and nonprod artifact registry
- **prod** profile: Uses production-gateway overlay and prod artifact registry
- Separate namespace configurations for each environment

## Testing
After this is merged, the Cloud Deploy release creation should successfully render manifests for both QA and Prod stages.