### PR TITLE
Add missing PodDisruptionBudget for production

### DIFF
--- a/k8s-clean/base/pod-disruption-budget.yaml
+++ b/k8s-clean/base/pod-disruption-budget.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: webapp-pdb
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: webapp
+      app.kubernetes.io/component: webapp
+  # Allow disruption during maintenance windows
+  unhealthyPodEvictionPolicy: AlwaysAllow


### PR DESCRIPTION
## Summary
Add the missing pod-disruption-budget.yaml file that is referenced by the production overlay.

## Context
The Cloud Deploy rendering for prod was failing with:
```
stat /workspace/source/k8s-clean/base/pod-disruption-budget.yaml: no such file or directory
```

The production overlay kustomization.yaml references this file but it didn't exist.

## Fix
Created a PodDisruptionBudget with:
- minAvailable: 2 (ensures at least 2 pods are always running)
- unhealthyPodEvictionPolicy: AlwaysAllow (allows disruption during maintenance)
- Proper label selectors matching the webapp deployment

This is a production best practice to ensure high availability during node maintenance or updates.

## Testing
After this is merged, the Cloud Deploy render for production should succeed.