### PR TITLE
Fix Config Connector namespace annotations for production deployments

### DIFF
--- a/k8s-clean/namespace/namespace-nonprod.yaml
+++ b/k8s-clean/namespace/namespace-nonprod.yaml
@@ -1,8 +1,10 @@
-# Namespace for webapp deployments
+# Namespace for webapp deployments in nonprod
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ${NAMESPACE} # from-param: ${NAMESPACE}
+  annotations:
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp-nonprod
   labels:
     app: webapp
     stage: ${STAGE} # from-param: ${STAGE}

--- a/k8s-clean/namespace/namespace-prod.yaml
+++ b/k8s-clean/namespace/namespace-prod.yaml
@@ -1,8 +1,10 @@
-# Namespace for webapp deployments
+# Namespace for webapp deployments in prod
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ${NAMESPACE} # from-param: ${NAMESPACE}
+  annotations:
+    cnrm.cloud.google.com/project-id: u2i-tenant-webapp-prod
   labels:
     app: webapp
     stage: ${STAGE} # from-param: ${STAGE}

--- a/skaffold-dev-deploy.yaml
+++ b/skaffold-dev-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
 # Namespace module - creates namespace for dev environment
 manifests:
   rawYaml:
-  - k8s-clean/namespace/namespace.yaml
+  - k8s-clean/namespace/namespace-nonprod.yaml
 deploy:
   kubectl:
     flags:

--- a/skaffold-gateway-preview.yaml
+++ b/skaffold-gateway-preview.yaml
@@ -5,7 +5,7 @@ metadata:
 # Namespace module - just renders and deploys namespace
 manifests:
   rawYaml:
-  - k8s-clean/namespace/namespace.yaml
+  - k8s-clean/namespace/namespace-nonprod.yaml
 deploy:
   kubectl:
     flags:

--- a/skaffold-preview-deploy.yaml
+++ b/skaffold-preview-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
 # Namespace module - just renders and deploys namespace
 manifests:
   rawYaml:
-  - k8s-clean/namespace/namespace.yaml
+  - k8s-clean/overlays/preview-gateway/namespace.yaml
 deploy:
   kubectl:
     flags:

--- a/skaffold-qa-prod.yaml
+++ b/skaffold-qa-prod.yaml
@@ -5,16 +5,19 @@ metadata:
 # Namespace module - creates namespace for both QA and Production environments
 manifests:
   rawYaml:
-  - k8s-clean/namespace/namespace.yaml
+  - k8s-clean/namespace/namespace-nonprod.yaml
 deploy:
   kubectl:
     flags:
       apply: ["--server-side", "--force-conflicts"]
 profiles:
 - name: qa
-  # QA namespace configuration
+  # QA namespace configuration - uses nonprod project
 - name: prod
-  # Production namespace configuration
+  # Production namespace configuration - uses prod project
+  manifests:
+    rawYaml:
+    - k8s-clean/namespace/namespace-prod.yaml
 ---
 apiVersion: skaffold/v4beta13
 kind: Config


### PR DESCRIPTION
## Summary
This PR fixes the production deployment failures by adding the required Config Connector project annotations to namespaces.

## Problem
Production deployments were failing with certificate resources timing out after 10 minutes. Investigation revealed:
- Config Connector resources need explicit project annotations on namespaces
- Without the annotation, Config Connector doesn't know which GCP project to create resources in
- This was documented in the infrastructure repo as a known issue

## Solution
- Add `cnrm.cloud.google.com/project-id` annotation to namespace manifests
- Create separate namespace files for nonprod and prod environments
- Update skaffold files to use the correct namespace file based on environment

## Changes
- Create `namespace-nonprod.yaml` with project annotation for nonprod environments
- Create `namespace-prod.yaml` with project annotation for prod environment
- Update skaffold files to use environment-specific namespace files
- Keep original `namespace.yaml` for backwards compatibility

## Testing
This change will be tested through the full deployment pipeline:
1. Preview deployment (PR)
2. Dev deployment (merge to main)
3. QA deployment (version tag)
4. Production deployment (promotion)

## Related Issues
- Fixes production certificate timeout issues
- Addresses Config Connector project reference problems
- Implements proper GitOps approach for environment-specific configuration

Closes #129