### PR TITLE
Fix HTTPRoute SERVICE_NAME parameter substitution

### DIFF
--- a/k8s-clean/overlays/dev-gateway/gateway-resources.yaml
+++ b/k8s-clean/overlays/dev-gateway/gateway-resources.yaml
@@ -22,5 +22,5 @@ spec:
     namespace: infra-gw
   rules:
   - backendRefs:
-    - name: webapp-service # from-param: ${SERVICE_NAME}
+    - name: ${SERVICE_NAME} # from-param: ${SERVICE_NAME}
       port: 80

--- a/k8s-clean/overlays/production-gateway/gateway-resources.yaml
+++ b/k8s-clean/overlays/production-gateway/gateway-resources.yaml
@@ -22,5 +22,5 @@ spec:
     namespace: infra-gw
   rules:
   - backendRefs:
-    - name: webapp-service # from-param: ${SERVICE_NAME}
+    - name: ${SERVICE_NAME} # from-param: ${SERVICE_NAME}
       port: 80

--- a/k8s-clean/overlays/qa-gateway/gateway-resources.yaml
+++ b/k8s-clean/overlays/qa-gateway/gateway-resources.yaml
@@ -22,5 +22,5 @@ spec:
     namespace: infra-gw
   rules:
   - backendRefs:
-    - name: webapp-service # from-param: ${SERVICE_NAME}
+    - name: ${SERVICE_NAME} # from-param: ${SERVICE_NAME}
       port: 80


### PR DESCRIPTION
## Summary
- Fixed HTTPRoute to use SERVICE_NAME parameter instead of hardcoded 'webapp-service'
- This was causing production deployments to fail because the service is named 'prod-webapp-service'
- Applied fix to all gateway overlays: production, qa, and dev

## Test plan
- [ ] Preview deployment should continue to work
- [ ] Dev deployment should continue to work  
- [ ] QA deployment should continue to work
- [ ] Production deployment should now succeed with correct service name

🤖 Generated with [Claude Code](https://claude.ai/code)