### PR TITLE
Fix deploy parameter syntax for proper substitution

### DIFF
--- a/k8s-clean/base/service.yaml
+++ b/k8s-clean/base/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: webapp-service # from-param: ${NAME_PREFIX}webapp-service
+  name: webapp-service # from-param: ${SERVICE_NAME}
   namespace: ${NAMESPACE} # from-param: ${NAMESPACE}
   labels:
     app: webapp

--- a/k8s-clean/overlays/dev-gateway/gateway-resources.yaml
+++ b/k8s-clean/overlays/dev-gateway/gateway-resources.yaml
@@ -22,5 +22,5 @@ spec:
     namespace: infra-gw
   rules:
   - backendRefs:
-    - name: ${SERVICE_NAME} # from-param: ${SERVICE_NAME}
+    - name: webapp-service # from-param: ${SERVICE_NAME}
       port: 80

--- a/k8s-clean/overlays/preview-gateway/gateway-resources.yaml
+++ b/k8s-clean/overlays/preview-gateway/gateway-resources.yaml
@@ -24,5 +24,5 @@ spec:
     namespace: infra-gw
   rules:
   - backendRefs:
-    - name: webapp-service # from-param: ${NAME_PREFIX}webapp-service
+    - name: webapp-service # from-param: ${SERVICE_NAME}
       port: 80

--- a/k8s-clean/overlays/production-gateway/gateway-resources.yaml
+++ b/k8s-clean/overlays/production-gateway/gateway-resources.yaml
@@ -22,5 +22,5 @@ spec:
     namespace: infra-gw
   rules:
   - backendRefs:
-    - name: ${SERVICE_NAME} # from-param: ${SERVICE_NAME}
+    - name: webapp-service # from-param: ${SERVICE_NAME}
       port: 80

--- a/k8s-clean/overlays/qa-gateway/gateway-resources.yaml
+++ b/k8s-clean/overlays/qa-gateway/gateway-resources.yaml
@@ -22,5 +22,5 @@ spec:
     namespace: infra-gw
   rules:
   - backendRefs:
-    - name: ${SERVICE_NAME} # from-param: ${SERVICE_NAME}
+    - name: webapp-service # from-param: ${SERVICE_NAME}
       port: 80


### PR DESCRIPTION
## Summary
- Fixed deploy parameter syntax to match Cloud Deploy documentation
- Previous syntax `${SERVICE_NAME}` was incorrect and not being substituted
- Correct syntax is: `webapp-service # from-param: ${SERVICE_NAME}`

## Problem
Production deployments were failing because the HTTPRoute was looking for 'webapp-service' but the actual service name is 'prod-webapp-service'. Our previous fix attempted to use `${SERVICE_NAME}` directly, but this isn't valid according to Cloud Deploy docs.

## Solution
Use the documented syntax where:
- The default value goes before the comment: `webapp-service`
- The parameter name goes after `from-param:`: `${SERVICE_NAME}`
- Cloud Deploy will replace the default value with the parameter value

## Test plan
- [ ] Preview deployments should continue to work
- [ ] Dev/QA deployments should continue to work
- [ ] Production deployment should now use 'prod-webapp-service' correctly without manual intervention

🤖 Generated with [Claude Code](https://claude.ai/code)