### PR TITLE
Test: Re-add PodDisruptionBudget to reproduce certificate timeout

### DIFF
--- a/k8s-clean/overlays/production-gateway/kustomization.yaml
+++ b/k8s-clean/overlays/production-gateway/kustomization.yaml
@@ -16,6 +16,9 @@ resources:
 # Gateway routing
 - gateway-resources.yaml
 
+# Production-specific resources
+- ../../base/pod-disruption-budget.yaml
+
 # Common labels for all resources
 commonLabels:
   app.kubernetes.io/component: webapp


### PR DESCRIPTION
## Purpose
This is a test PR to verify if re-adding the PodDisruptionBudget causes the Config Connector certificate timeout issue to reappear.

## Expected Behavior
If our hypothesis is correct:
- Dev and QA deployments should continue to work (no PDB)
- Production deployment should fail with certificate timeout after 10 minutes

## What to Watch For
- Look for resources tracked without namespace prefix in the logs
- Check if we see both `webapp-prod:config-connector-resource/...` and `config-connector-resource/...`
- Monitor if certificates timeout after exactly 10 minutes

This will help confirm the correlation between deployment complexity and Skaffold issue #7207.

🤖 Generated with [Claude Code](https://claude.ai/code)