### PR TITLE
Test: Verify split configuration works for preview deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the WebApp Team's application deployment infrastructure following ISO 27001, SOC 2 Type II, and GDPR compliance requirements.
 
-Test PR 85 - Single stage deployment with status checks enabled
+Test PR - Verifying split configuration for preview deployments
 
 ## 🏗️ Repository Structure
 


### PR DESCRIPTION
Testing that the split Skaffold configuration from commit df6dcbf works correctly for preview deployments.

This is to establish a baseline before making further changes.