### PR TITLE
Fix: Add namespace parameter to PodDisruptionBudget

### DIFF
--- a/k8s-clean/base/pod-disruption-budget.yaml
+++ b/k8s-clean/base/pod-disruption-budget.yaml
@@ -2,6 +2,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: webapp-pdb
+  namespace: ${NAMESPACE} # from-param: ${NAMESPACE}
 spec:
   minAvailable: 2
   selector:


### PR DESCRIPTION
## Summary
- Added `namespace: ${NAMESPACE}` parameter to PodDisruptionBudget
- Fixes issue where PDB was being created in default namespace instead of environment-specific namespace

## Problem
The PodDisruptionBudget was missing the namespace parameter that other resources use, causing it to be created in the default namespace instead of the correct environment namespace (webapp-qa, webapp-prod, etc).

## Solution
Added `namespace: ${NAMESPACE} # from-param: ${NAMESPACE}` to the PDB metadata, following the same pattern as deployment.yaml and service.yaml.

## Test Plan
- [ ] Deploy to preview environment
- [ ] Verify PDB is created in webapp-preview namespace
- [ ] Deploy to production
- [ ] Verify PDB is created in webapp-prod namespace

🤖 Generated with [Claude Code](https://claude.ai/code)