### PR TITLE
Fix QA/Prod deployment selector to match existing deployments

### DIFF
--- a/k8s-clean/base/deployment.yaml
+++ b/k8s-clean/base/deployment.yaml
@@ -14,14 +14,10 @@ spec:
   selector:
     matchLabels:
       app: webapp
-      app.kubernetes.io/component: webapp
-      environment: ${ENV} # from-param: ${ENV}
   template:
     metadata:
       labels:
         app: webapp
-        app.kubernetes.io/component: webapp
-        environment: ${ENV} # from-param: ${ENV}
         tenant: webapp-team
         compliance: iso27001-soc2-gdpr
         data-residency: eu


### PR DESCRIPTION
## Summary
- Reverted the additional selector labels that were causing QA deployment failures
- QA and Prod deployments already exist with only `app: webapp` selector
- Deployment selectors are immutable, so we must match what's already deployed

## Test plan
- [ ] Preview deployment should succeed
- [ ] Dev deployment should continue working
- [ ] QA deployment should succeed after merging and tagging
- [ ] Prod deployment should work after QA promotion

🤖 Generated with [Claude Code](https://claude.ai/code)