### PR TITLE
Remove hardcoded values from KCC overlays

### DIFF
--- a/k8s-clean/kcc/overlays/dev/kustomization.yaml
+++ b/k8s-clean/kcc/overlays/dev/kustomization.yaml
@@ -3,60 +3,13 @@ kind: Kustomization
 
 # KCC resources for dev environment
 # These are deployed with statusCheck disabled to avoid Skaffold bug #7207
+# All values come from Cloud Deploy parameters - no patches needed
 
 resources:
-# Use base certificate template
+# Use base certificate template with parameters
 - ../../../base/certificate-template.yaml
 
 # Common labels for all KCC resources
 commonLabels:
   app.kubernetes.io/component: webapp
   environment: dev
-
-# Patches to set dev-specific values
-patches:
-- target:
-    kind: CertificateManagerCertificate
-    name: webapp-cert
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: webapp-dev-cert
-    - op: replace
-      path: /metadata/namespace
-      value: webapp-dev
-    - op: replace
-      path: /metadata/annotations/cnrm.cloud.google.com~1project-id
-      value: u2i-tenant-webapp-nonprod
-    - op: replace
-      path: /spec/projectRef/external
-      value: u2i-tenant-webapp-nonprod
-    - op: replace
-      path: /spec/description
-      value: Certificate for dev.webapp.u2i.dev
-    - op: replace
-      path: /spec/managed/domains/0
-      value: dev.webapp.u2i.dev
-
-- target:
-    kind: CertificateManagerCertificateMapEntry
-    name: webapp-entry
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: webapp-dev-entry
-    - op: replace
-      path: /metadata/namespace
-      value: webapp-dev
-    - op: replace
-      path: /metadata/annotations/cnrm.cloud.google.com~1project-id
-      value: u2i-tenant-webapp-nonprod
-    - op: replace
-      path: /spec/projectRef/external
-      value: u2i-tenant-webapp-nonprod
-    - op: replace
-      path: /spec/hostname
-      value: dev.webapp.u2i.dev
-    - op: replace
-      path: /spec/certificatesRefs/0/name
-      value: webapp-dev-cert

--- a/k8s-clean/kcc/overlays/production/kustomization.yaml
+++ b/k8s-clean/kcc/overlays/production/kustomization.yaml
@@ -3,9 +3,10 @@ kind: Kustomization
 
 # KCC resources for production environment
 # These are deployed with statusCheck disabled to avoid Skaffold bug #7207
+# All values come from Cloud Deploy parameters - no patches needed
 
 resources:
-# Use base certificate template
+# Use base certificate template with parameters
 - ../../../base/certificate-template.yaml
 
 # Common labels for all KCC resources
@@ -14,51 +15,3 @@ commonLabels:
   environment: prod
   compliance: iso27001-soc2-gdpr
   data-residency: eu
-
-# Patches to set production-specific values
-patches:
-- target:
-    kind: CertificateManagerCertificate
-    name: webapp-cert
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: webapp-prod-cert
-    - op: replace
-      path: /metadata/namespace
-      value: webapp-prod
-    - op: replace
-      path: /metadata/annotations/cnrm.cloud.google.com~1project-id
-      value: u2i-tenant-webapp-prod
-    - op: replace
-      path: /spec/projectRef/external
-      value: u2i-tenant-webapp-prod
-    - op: replace
-      path: /spec/description
-      value: Certificate for webapp.u2i.com
-    - op: replace
-      path: /spec/managed/domains/0
-      value: webapp.u2i.com
-
-- target:
-    kind: CertificateManagerCertificateMapEntry
-    name: webapp-entry
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: webapp-prod-entry
-    - op: replace
-      path: /metadata/namespace
-      value: webapp-prod
-    - op: replace
-      path: /metadata/annotations/cnrm.cloud.google.com~1project-id
-      value: u2i-tenant-webapp-prod
-    - op: replace
-      path: /spec/projectRef/external
-      value: u2i-tenant-webapp-prod
-    - op: replace
-      path: /spec/hostname
-      value: webapp.u2i.com
-    - op: replace
-      path: /spec/certificatesRefs/0/name
-      value: webapp-prod-cert

--- a/k8s-clean/kcc/overlays/qa/kustomization.yaml
+++ b/k8s-clean/kcc/overlays/qa/kustomization.yaml
@@ -3,9 +3,10 @@ kind: Kustomization
 
 # KCC resources for QA environment
 # These are deployed with statusCheck disabled to avoid Skaffold bug #7207
+# All values come from Cloud Deploy parameters - no patches needed
 
 resources:
-# Use base certificate template
+# Use base certificate template with parameters
 - ../../../base/certificate-template.yaml
 
 # Common labels for all KCC resources
@@ -13,51 +14,3 @@ commonLabels:
   app.kubernetes.io/component: webapp
   environment: qa
   compliance: iso27001-soc2-gdpr
-
-# Patches to set QA-specific values
-patches:
-- target:
-    kind: CertificateManagerCertificate
-    name: webapp-cert
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: webapp-qa-cert
-    - op: replace
-      path: /metadata/namespace
-      value: webapp-qa
-    - op: replace
-      path: /metadata/annotations/cnrm.cloud.google.com~1project-id
-      value: u2i-tenant-webapp-nonprod
-    - op: replace
-      path: /spec/projectRef/external
-      value: u2i-tenant-webapp-nonprod
-    - op: replace
-      path: /spec/description
-      value: Certificate for qa.webapp.u2i.dev
-    - op: replace
-      path: /spec/managed/domains/0
-      value: qa.webapp.u2i.dev
-
-- target:
-    kind: CertificateManagerCertificateMapEntry
-    name: webapp-entry
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: webapp-qa-entry
-    - op: replace
-      path: /metadata/namespace
-      value: webapp-qa
-    - op: replace
-      path: /metadata/annotations/cnrm.cloud.google.com~1project-id
-      value: u2i-tenant-webapp-nonprod
-    - op: replace
-      path: /spec/projectRef/external
-      value: u2i-tenant-webapp-nonprod
-    - op: replace
-      path: /spec/hostname
-      value: qa.webapp.u2i.dev
-    - op: replace
-      path: /spec/certificatesRefs/0/name
-      value: webapp-qa-cert


### PR DESCRIPTION
## Summary
- Removed 12 hardcoded project ID references from KCC overlays
- Eliminated all hardcoded certificate parameters (names, domains, descriptions)
- Reduced KCC overlay files by 141 lines total (80% reduction)

## Changes
- ✅ Dev KCC overlay: Removed 48 lines of hardcoded patches
- ✅ QA KCC overlay: Removed 48 lines of hardcoded patches  
- ✅ Production KCC overlay: Removed 48 lines of hardcoded patches

## Why this works
The base certificate template already uses parameters:
- `${PROJECT_ID}`
- `${CERT_NAME}`
- `${CERT_ENTRY_NAME}`
- `${CERT_DESCRIPTION}`
- `${DOMAIN}`

These parameters are provided by Cloud Deploy, so the manual patches were redundant.

## Test plan
- [ ] Preview deployment should create certificates with correct values
- [ ] Dev deployment should work without hardcoded patches
- [ ] QA deployment should work without hardcoded patches
- [ ] Production deployment should work without hardcoded patches

🤖 Generated with [Claude Code](https://claude.ai/code)