### PR TITLE
Fix resource profiles - restore proper sizing

### DIFF
--- a/clouddeploy-dev.yaml
+++ b/clouddeploy-dev.yaml
@@ -35,16 +35,6 @@ serialPipeline:
           CERT_DESCRIPTION: "Certificate for dev.webapp.u2i.dev"
           PROJECT_ID: "u2i-tenant-webapp-nonprod"
           PDB_MIN_AVAILABLE: "1"
-          # Resource parameters for preprod profile
-          REPLICAS: "1"
-          MEMORY_REQUEST: "64Mi"
-          CPU_REQUEST: "50m"
-          MEMORY_LIMIT: "128Mi"
-          CPU_LIMIT: "100m"
-          # Config parameters
-          PROFILE: "dev"
-          LOG_LEVEL: "debug"
-          GRACEFUL_SHUTDOWN_TIMEOUT: "5s"
 
 ---
 apiVersion: deploy.cloud.google.com/v1

--- a/clouddeploy-preview.yaml
+++ b/clouddeploy-preview.yaml
@@ -18,18 +18,6 @@ serialPipeline:
     strategy:
       standard:
         verify: false
-    deployParameters:
-      - values:
-          # Resource parameters for preview profile
-          REPLICAS: "1"
-          MEMORY_REQUEST: "64Mi"
-          CPU_REQUEST: "50m"
-          MEMORY_LIMIT: "128Mi"
-          CPU_LIMIT: "100m"
-          # Config parameters
-          PROFILE: "preview"
-          LOG_LEVEL: "debug"
-          GRACEFUL_SHUTDOWN_TIMEOUT: "5s"
 
 ---
 apiVersion: deploy.cloud.google.com/v1

--- a/clouddeploy-qa-prod.yaml
+++ b/clouddeploy-qa-prod.yaml
@@ -34,16 +34,6 @@ serialPipeline:
           CERT_DESCRIPTION: "Certificate for qa.webapp.u2i.dev"
           PROJECT_ID: "u2i-tenant-webapp-nonprod"
           PDB_MIN_AVAILABLE: "1"
-          # Resource parameters for preprod profile
-          REPLICAS: "2"
-          MEMORY_REQUEST: "128Mi"
-          CPU_REQUEST: "100m"
-          MEMORY_LIMIT: "256Mi"
-          CPU_LIMIT: "200m"
-          # Config parameters
-          PROFILE: "qa"
-          LOG_LEVEL: "info"
-          GRACEFUL_SHUTDOWN_TIMEOUT: "10s"
   - targetId: prod-gke
     profiles:
       - prod
@@ -66,18 +56,6 @@ serialPipeline:
           CERT_DESCRIPTION: "Certificate for webapp.u2i.com"
           PROJECT_ID: "u2i-tenant-webapp-prod"
           PDB_MIN_AVAILABLE: "2"
-          # Resource parameters for prod profile
-          REPLICAS: "3"
-          MEMORY_REQUEST: "512Mi"
-          CPU_REQUEST: "500m"
-          MEMORY_LIMIT: "1Gi"
-          CPU_LIMIT: "1000m"
-          # Config parameters
-          PROFILE: "prod"
-          LOG_LEVEL: "info"
-          GRACEFUL_SHUTDOWN_TIMEOUT: "30s"
-          ENABLE_PROFILING: "false"
-          ENABLE_METRICS: "true"
 
 ---
 # QA Target

--- a/k8s/app/resources/preprod/kustomization.yaml
+++ b/k8s/app/resources/preprod/kustomization.yaml
@@ -10,20 +10,20 @@ patches:
   patch: |-
     - op: replace
       path: /spec/replicas
-      value: ${REPLICAS} # from-param: ${REPLICAS}
+      value: 1
     - op: replace
       path: /spec/template/spec/containers/0/resources
       value:
         requests:
-          memory: "${MEMORY_REQUEST}" # from-param: ${MEMORY_REQUEST}
-          cpu: "${CPU_REQUEST}" # from-param: ${CPU_REQUEST}
+          memory: "64Mi"
+          cpu: "50m"
         limits:
-          memory: "${MEMORY_LIMIT}" # from-param: ${MEMORY_LIMIT}
-          cpu: "${CPU_LIMIT}" # from-param: ${CPU_LIMIT}
+          memory: "128Mi"
+          cpu: "100m"
 
 configMapGenerator:
 - name: webapp-profile-config
   literals:
-    - PROFILE=${PROFILE} # from-param: ${PROFILE}
-    - LOG_LEVEL=${LOG_LEVEL} # from-param: ${LOG_LEVEL}
-    - GRACEFUL_SHUTDOWN_TIMEOUT=${GRACEFUL_SHUTDOWN_TIMEOUT} # from-param: ${GRACEFUL_SHUTDOWN_TIMEOUT}
+    - PROFILE=preprod
+    - LOG_LEVEL=debug
+    - GRACEFUL_SHUTDOWN_TIMEOUT=5s

--- a/k8s/app/resources/preview/kustomization.yaml
+++ b/k8s/app/resources/preview/kustomization.yaml
@@ -10,20 +10,20 @@ patches:
   patch: |-
     - op: replace
       path: /spec/replicas
-      value: ${REPLICAS} # from-param: ${REPLICAS}
+      value: 1
     - op: replace
       path: /spec/template/spec/containers/0/resources
       value:
         requests:
-          memory: "${MEMORY_REQUEST}" # from-param: ${MEMORY_REQUEST}
-          cpu: "${CPU_REQUEST}" # from-param: ${CPU_REQUEST}
+          memory: "64Mi"
+          cpu: "50m"
         limits:
-          memory: "${MEMORY_LIMIT}" # from-param: ${MEMORY_LIMIT}
-          cpu: "${CPU_LIMIT}" # from-param: ${CPU_LIMIT}
+          memory: "128Mi"
+          cpu: "100m"
 
 configMapGenerator:
 - name: webapp-profile-config
   literals:
-    - PROFILE=${PROFILE} # from-param: ${PROFILE}
-    - LOG_LEVEL=${LOG_LEVEL} # from-param: ${LOG_LEVEL}
-    - GRACEFUL_SHUTDOWN_TIMEOUT=${GRACEFUL_SHUTDOWN_TIMEOUT} # from-param: ${GRACEFUL_SHUTDOWN_TIMEOUT}
+    - PROFILE=preview
+    - LOG_LEVEL=debug
+    - GRACEFUL_SHUTDOWN_TIMEOUT=5s

--- a/k8s/app/resources/prod/kustomization.yaml
+++ b/k8s/app/resources/prod/kustomization.yaml
@@ -10,16 +10,16 @@ patches:
   patch: |-
     - op: replace
       path: /spec/replicas
-      value: ${REPLICAS} # from-param: ${REPLICAS}
+      value: 3
     - op: replace
       path: /spec/template/spec/containers/0/resources
       value:
         requests:
-          memory: "${MEMORY_REQUEST}" # from-param: ${MEMORY_REQUEST}
-          cpu: "${CPU_REQUEST}" # from-param: ${CPU_REQUEST}
+          memory: "512Mi"
+          cpu: "500m"
         limits:
-          memory: "${MEMORY_LIMIT}" # from-param: ${MEMORY_LIMIT}
-          cpu: "${CPU_LIMIT}" # from-param: ${CPU_LIMIT}
+          memory: "1Gi"
+          cpu: "1000m"
     - op: add
       path: /spec/template/spec/affinity
       value:
@@ -41,8 +41,8 @@ resources:
 configMapGenerator:
 - name: webapp-profile-config
   literals:
-    - PROFILE=${PROFILE} # from-param: ${PROFILE}
-    - LOG_LEVEL=${LOG_LEVEL} # from-param: ${LOG_LEVEL}
-    - GRACEFUL_SHUTDOWN_TIMEOUT=${GRACEFUL_SHUTDOWN_TIMEOUT} # from-param: ${GRACEFUL_SHUTDOWN_TIMEOUT}
-    - ENABLE_PROFILING=${ENABLE_PROFILING} # from-param: ${ENABLE_PROFILING}
-    - ENABLE_METRICS=${ENABLE_METRICS} # from-param: ${ENABLE_METRICS}
+    - PROFILE=prod
+    - LOG_LEVEL=info
+    - GRACEFUL_SHUTDOWN_TIMEOUT=30s
+    - ENABLE_PROFILING=false
+    - ENABLE_METRICS=true


### PR DESCRIPTION
## Summary
Fixes the resource profiles to use hardcoded values, restoring the proper resource sizing per environment.

## Problem
In PR #161, we attempted to parameterize the resource values in Kustomize patches, but Kustomize doesn't support parameter substitution in patches. This resulted in all environments using the default values from deployment.yaml instead of environment-specific values.

## Solution
Reverted to hardcoded values in the resource profiles (like before), maintaining:
- **Preview/Preprod**: 64Mi/128Mi memory, 50m/100m CPU, 1 replica
- **Production**: 512Mi/1Gi memory, 500m/1000m CPU, 3 replicas

Also removed the unused parameters from Cloud Deploy configs since they weren't being applied.

## Test plan
- [ ] Preview deployment uses correct resources (64Mi/128Mi)
- [ ] Dev deployment uses correct resources after merge
- [ ] QA deployment uses correct resources after tagging
- [ ] Production deployment uses correct resources (512Mi/1Gi)

🤖 Generated with [Claude Code](https://claude.ai/code)