### PR TITLE
Fix kustomize profiles to properly apply resource limits

### DIFF
--- a/k8s/app/resources/preprod/kustomization.yaml
+++ b/k8s/app/resources/preprod/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 
 # Preprod profile - medium resources for dev/qa environments
 
+resources:
+- ../../base
+
 patches:
 - target:
     kind: Deployment

--- a/k8s/app/resources/preview/kustomization.yaml
+++ b/k8s/app/resources/preview/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 
 # Preview profile - small resources for PR preview environments
 
+resources:
+- ../../base
+
 patches:
 - target:
     kind: Deployment

--- a/k8s/app/resources/prod/kustomization.yaml
+++ b/k8s/app/resources/prod/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 
 # Prod profile - production-grade resources and high availability
 
+resources:
+- ../../base
+
 patches:
 - target:
     kind: Deployment

--- a/skaffold-dev.yaml
+++ b/skaffold-dev.yaml
@@ -23,7 +23,6 @@ build:
 manifests:
   kustomize:
     paths:
-    - k8s/app/base
     - k8s/app/resources/preprod
     buildArgs:
     - --load-restrictor=LoadRestrictionsNone

--- a/skaffold-preview.yaml
+++ b/skaffold-preview.yaml
@@ -25,7 +25,6 @@ build:
 manifests:
   kustomize:
     paths:
-    - k8s/app/base
     - k8s/app/resources/preview
     buildArgs:
     - --load-restrictor=LoadRestrictionsNone

--- a/skaffold-qa-prod.yaml
+++ b/skaffold-qa-prod.yaml
@@ -39,7 +39,6 @@ profiles:
   manifests:
     kustomize:
       paths:
-      - k8s/app/base
       - k8s/app/resources/preprod
       buildArgs:
       - --load-restrictor=LoadRestrictionsNone
@@ -50,7 +49,6 @@ profiles:
   manifests:
     kustomize:
       paths:
-      - k8s/app/base
       - k8s/app/resources/prod
       buildArgs:
       - --load-restrictor=LoadRestrictionsNone


### PR DESCRIPTION
## Summary
Fixes the kustomize resource profiles so they actually apply the environment-specific resource limits.

## Problem
The resource profiles weren't working because:
1. They only contained patches without referencing any resources to patch
2. Skaffold was loading both base and profile, but kustomize doesn't merge them properly

## Solution
1. Each profile now includes `resources: - ../../base` to load the base resources
2. Updated Skaffold to only reference the profile path (which now includes base)
3. This ensures patches are applied on top of the base resources

## Expected Results
- **Preview/Preprod**: 1 replica, 64Mi/128Mi memory, 50m/100m CPU
- **Production**: 3 replicas, 512Mi/1Gi memory, 500m/1000m CPU

## Test plan
- [ ] Preview deployment uses correct resources
- [ ] Dev deployment uses correct resources after merge
- [ ] QA deployment uses correct resources after tagging
- [ ] Production deployment uses correct resources

🤖 Generated with [Claude Code](https://claude.ai/code)