### PR TITLE
Fix Skaffold profiles to properly apply resource limits

### DIFF
--- a/skaffold-dev.yaml
+++ b/skaffold-dev.yaml
@@ -20,12 +20,6 @@ metadata:
 build:
   artifacts:
   - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-nonprod/webapp-images/webapp
-manifests:
-  kustomize:
-    paths:
-    - k8s/app/resources/preprod
-    buildArgs:
-    - --load-restrictor=LoadRestrictionsNone
 deploy:
   kubectl:
     flags:
@@ -33,6 +27,12 @@ deploy:
   statusCheck: true  # Enable status checking for app resources
 profiles:
 - name: dev
+  manifests:
+    kustomize:
+      paths:
+      - k8s/app/resources/preprod
+      buildArgs:
+      - --load-restrictor=LoadRestrictionsNone
 ---
 apiVersion: skaffold/v4beta13
 kind: Config

--- a/skaffold-preview.yaml
+++ b/skaffold-preview.yaml
@@ -22,12 +22,6 @@ metadata:
 build:
   artifacts:
   - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-nonprod/webapp-images/webapp
-manifests:
-  kustomize:
-    paths:
-    - k8s/app/resources/preview
-    buildArgs:
-    - --load-restrictor=LoadRestrictionsNone
 deploy:
   kubectl:
     flags:
@@ -35,6 +29,12 @@ deploy:
   statusCheck: true  # Enable status checking for app resources
 profiles:
 - name: preview-all
+  manifests:
+    kustomize:
+      paths:
+      - k8s/app/resources/preview
+      buildArgs:
+      - --load-restrictor=LoadRestrictionsNone
 ---
 apiVersion: skaffold/v4beta13
 kind: Config

--- a/skaffold-qa-prod.yaml
+++ b/skaffold-qa-prod.yaml
@@ -23,12 +23,6 @@ metadata:
 build:
   artifacts:
   - image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-nonprod/webapp-images/webapp
-manifests:
-  kustomize:
-    paths:
-    - k8s-clean/overlays/qa  # Default to QA
-    buildArgs:
-    - --load-restrictor=LoadRestrictionsNone
 deploy:
   kubectl:
     flags:


### PR DESCRIPTION
## Summary
Moves the manifests configuration into the profile sections so that Skaffold actually uses the resource profiles.

## Problem
The kustomize profiles work correctly (tested locally), but Skaffold wasn't using them because:
- Manifests were defined at the root level of each Skaffold module
- Profiles had empty or duplicate manifest sections
- Skaffold was using the root manifest instead of the profile-specific one

## Solution
- Removed root-level manifests sections
- Moved manifests configuration into each profile
- Each profile now properly points to its resource profile (preview, preprod, prod)

## Testing
Tested locally:
```bash
# Preview profile correctly shows:
kustomize build k8s/app/resources/preview
# - replicas: 1
# - memory: 64Mi/128Mi
# - cpu: 50m/100m

# Prod profile correctly shows:
kustomize build k8s/app/resources/prod
# - replicas: 3
# - memory: 512Mi/1Gi
# - cpu: 500m/1000m
```

## Expected Results
This should finally apply the correct resource limits:
- **Preview/Dev/QA**: 1 replica, 64Mi/128Mi memory, 50m/100m CPU
- **Production**: 3 replicas, 512Mi/1Gi memory, 500m/1000m CPU

## Test plan
- [ ] Preview deployment uses correct resources
- [ ] Dev deployment uses correct resources after merge
- [ ] QA deployment uses correct resources after tagging
- [ ] Production deployment uses correct resources

🤖 Generated with [Claude Code](https://claude.ai/code)