### PR TITLE
Fix resource profiles by using labelSelector

### DIFF
--- a/k8s/app/resources/preprod/kustomization.yaml
+++ b/k8s/app/resources/preprod/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 patches:
 - target:
     kind: Deployment
-    name: webapp
+    labelSelector: app=webapp
   patch: |-
     - op: replace
       path: /spec/replicas

--- a/k8s/app/resources/preview/kustomization.yaml
+++ b/k8s/app/resources/preview/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 patches:
 - target:
     kind: Deployment
-    name: webapp
+    labelSelector: app=webapp
   patch: |-
     - op: replace
       path: /spec/replicas

--- a/k8s/app/resources/prod/kustomization.yaml
+++ b/k8s/app/resources/prod/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 patches:
 - target:
     kind: Deployment
-    name: webapp
+    labelSelector: app=webapp
   patch: |-
     - op: replace
       path: /spec/replicas


### PR DESCRIPTION
## Summary
Minimal fix to make resource profiles work by using labelSelector instead of name-based targeting.

## Problem
The kustomize patches introduced in PR #161 weren't being applied because:
- Base deployment has parameterized namespace: `namespace: ${NAMESPACE}`
- Patches targeting by `name: webapp` couldn't match the deployment

## Solution
Change from:
```yaml
- target:
    kind: Deployment
    name: webapp
```

To:
```yaml
- target:
    kind: Deployment
    labelSelector: app=webapp
```

This avoids namespace/name matching issues and works correctly with Cloud Deploy's parameter substitution.

## Expected Results
With this fix, the resource profiles from PR #161 should finally work:
- Preview: 1 replica, 64Mi/128Mi memory, 50m/100m CPU
- Dev/QA: Values from deployParameters in Cloud Deploy configs
- Prod: 3 replicas, 512Mi/1Gi memory, 500m/1000m CPU

Closes #162, #163, #164, #165, #166, #167, #168