### PR TITLE
Test config-based compliance-cli v0.3.0

### DIFF
--- a/.compliance-cli.yaml
+++ b/.compliance-cli.yaml
@@ -1,0 +1,15 @@
+# Compliance CLI configuration for webapp-team-app
+# All fields are required
+
+# Application identifier
+app: webapp
+
+# GCP projects
+projects:
+  nonprod: u2i-tenant-webapp-nonprod
+  prod: u2i-tenant-webapp-prod
+
+# Domain configuration  
+domains:
+  nonprod_base: u2i.dev
+  prod_base: u2i.com

--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ app.get('/ready', (req, res) => {
 
 app.get('/', (req, res) => {
   res.json({
-    message: 'Hello from webapp-team! v6 - Testing Preview Deployments',
+    message: 'Hello from webapp! v7 - Testing Config-based CLI',
     boundary: boundary,
     stage: stage,
     version: version,


### PR DESCRIPTION
## Summary
This PR tests the new configuration file support in compliance-cli v0.3.0.

## Changes
- Added `.compliance-cli.yaml` configuration file
- Updated app message to v7
- No changes to deployment scripts needed

## Testing
The preview deployment will test if the new CLI correctly:
1. Reads the config file
2. Derives all values from the minimal config
3. Deploys successfully using the config

## Config File
The webapp now uses this simple config:
```yaml
app: webapp
projects:
  nonprod: u2i-tenant-webapp-nonprod
  prod: u2i-tenant-webapp-prod
domains:
  nonprod_base: u2i.dev
  prod_base: u2i.com
```

Everything else is automatically derived by the CLI.