### PR TITLE
Parameterize app name in Kubernetes manifests

### DIFF
--- a/deploy/clouddeploy/dev.yaml
+++ b/deploy/clouddeploy/dev.yaml
@@ -35,6 +35,7 @@ serialPipeline:
           CERT_DESCRIPTION: "Certificate for dev.webapp.u2i.dev"
           PROJECT_ID: "u2i-tenant-webapp-nonprod"
           PDB_MIN_AVAILABLE: "1"
+          APP_NAME: "webapp"
 
 ---
 apiVersion: deploy.cloud.google.com/v1

--- a/deploy/clouddeploy/preview.yaml
+++ b/deploy/clouddeploy/preview.yaml
@@ -18,6 +18,9 @@ serialPipeline:
     strategy:
       standard:
         verify: false
+    deployParameters:
+      - values:
+          APP_NAME: "webapp"
 
 ---
 apiVersion: deploy.cloud.google.com/v1

--- a/deploy/clouddeploy/qa-prod.yaml
+++ b/deploy/clouddeploy/qa-prod.yaml
@@ -34,6 +34,7 @@ serialPipeline:
           CERT_DESCRIPTION: "Certificate for qa.webapp.u2i.dev"
           PROJECT_ID: "u2i-tenant-webapp-nonprod"
           PDB_MIN_AVAILABLE: "1"
+          APP_NAME: "webapp"
   - targetId: prod-gke
     profiles:
       - prod
@@ -56,6 +57,7 @@ serialPipeline:
           CERT_DESCRIPTION: "Certificate for webapp.u2i.com"
           PROJECT_ID: "u2i-tenant-webapp-prod"
           PDB_MIN_AVAILABLE: "2"
+          APP_NAME: "webapp"
 
 ---
 # QA Target

--- a/k8s/app/base/deployment.yaml
+++ b/k8s/app/base/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: webapp # from-param: ${NAME_PREFIX}webapp
+  name: webapp # from-param: ${NAME_PREFIX}${APP_NAME}
   namespace: ${NAMESPACE} # from-param: ${NAMESPACE}
   labels:
-    app: webapp
+    app: webapp # from-param: ${APP_NAME}
     stage: ${STAGE} # from-param: ${STAGE}
     boundary: ${BOUNDARY} # from-param: ${BOUNDARY}
     tier: ${TIER} # from-param: ${TIER}
@@ -13,12 +13,12 @@ spec:
   replicas: 2
   selector:
     matchLabels:
-      app: webapp
+      app: webapp # from-param: ${APP_NAME}
   template:
     metadata:
       labels:
-        app: webapp
-        tenant: webapp-team
+        app: webapp # from-param: ${APP_NAME}
+        tenant: webapp-team # from-param: ${APP_NAME}-team
         compliance: iso27001-soc2-gdpr
         data-residency: eu
       annotations:
@@ -32,7 +32,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-      - name: webapp
+      - name: webapp # from-param: ${APP_NAME}
         image: europe-west1-docker.pkg.dev/u2i-tenant-webapp-nonprod/webapp-images/webapp
         ports:
         - containerPort: 8080

--- a/k8s/app/base/httproute.yaml
+++ b/k8s/app/base/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
   name: webapp-route # from-param: ${ROUTE_NAME}
   namespace: ${NAMESPACE} # from-param: ${NAMESPACE}
   labels:
-    app: webapp
+    app: webapp # from-param: ${APP_NAME}
     stage: ${STAGE} # from-param: ${STAGE}
     boundary: ${BOUNDARY} # from-param: ${BOUNDARY}
     tier: ${TIER} # from-param: ${TIER}

--- a/k8s/app/base/network-policy.yaml
+++ b/k8s/app/base/network-policy.yaml
@@ -1,10 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: webapp-network-policy # from-param: ${NAME_PREFIX}webapp-network-policy
+  name: webapp-network-policy # from-param: ${NAME_PREFIX}${APP_NAME}-network-policy
   namespace: ${NAMESPACE} # from-param: ${NAMESPACE}
   labels:
-    app: webapp
+    app: webapp # from-param: ${APP_NAME}
     stage: ${STAGE} # from-param: ${STAGE}
     boundary: ${BOUNDARY} # from-param: ${BOUNDARY}
     tier: ${TIER} # from-param: ${TIER}
@@ -12,7 +12,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: webapp
+      app: webapp # from-param: ${APP_NAME}
   policyTypes:
   - Ingress
   - Egress

--- a/k8s/app/base/pod-disruption-budget.yaml
+++ b/k8s/app/base/pod-disruption-budget.yaml
@@ -1,13 +1,13 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: webapp-pdb
+  name: webapp-pdb # from-param: ${APP_NAME}-pdb
   namespace: ${NAMESPACE} # from-param: ${NAMESPACE}
 spec:
   minAvailable: ${PDB_MIN_AVAILABLE} # from-param: ${PDB_MIN_AVAILABLE}
   selector:
     matchLabels:
-      app: webapp
+      app: webapp # from-param: ${APP_NAME}
   # Allow disruption during maintenance windows
   unhealthyPodEvictionPolicy: AlwaysAllow
   # Note: PDB selector only needs to match a subset of pod labels

--- a/k8s/app/base/service.yaml
+++ b/k8s/app/base/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: webapp-service # from-param: ${SERVICE_NAME}
   namespace: ${NAMESPACE} # from-param: ${NAMESPACE}
   labels:
-    app: webapp
+    app: webapp # from-param: ${APP_NAME}
     stage: ${STAGE} # from-param: ${STAGE}
     boundary: ${BOUNDARY} # from-param: ${BOUNDARY}
     tier: ${TIER} # from-param: ${TIER}
@@ -12,7 +12,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: webapp
+    app: webapp # from-param: ${APP_NAME}
   ports:
     - port: 80
       targetPort: 8080

--- a/k8s/app/resources/prod/horizontal-pod-autoscaler.yaml
+++ b/k8s/app/resources/prod/horizontal-pod-autoscaler.yaml
@@ -1,12 +1,12 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: webapp-hpa
+  name: webapp-hpa # from-param: ${APP_NAME}-hpa
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: webapp
+    name: webapp # from-param: ${APP_NAME}
   minReplicas: 3
   maxReplicas: 10
   metrics:

--- a/k8s/namespace/namespace.yaml
+++ b/k8s/namespace/namespace.yaml
@@ -7,14 +7,14 @@ metadata:
     cnrm.cloud.google.com/project-id: ${PROJECT_ID} # from-param: ${PROJECT_ID}
   labels:
     name: ${NAMESPACE} # from-param: ${NAMESPACE}
-    app: webapp
+    app: webapp # from-param: ${APP_NAME}
     stage: ${STAGE} # from-param: ${STAGE}
     boundary: ${BOUNDARY} # from-param: ${BOUNDARY}
     tier: ${TIER} # from-param: ${TIER}
     environment: ${ENV} # from-param: ${ENV}
     compliance: iso27001-soc2-gdpr
     data-residency: eu
-    tenant: webapp-team
+    tenant: webapp-team # from-param: ${APP_NAME}-team
     istio-injection: enabled
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/audit: restricted


### PR DESCRIPTION
## Summary
- Parameterized all `webapp` references in Kubernetes manifests using Cloud Deploy's `from-param` syntax
- Added `APP_NAME` parameter to all Cloud Deploy configurations (dev, preview, qa, prod)
- Updated compliance-cli to pass `APP_NAME` parameter during deployments

## Changes
- Updated app labels, selectors, container names, and resource names to use `${APP_NAME}` parameter
- Kept infrastructure resources (webapp-gateway, webapp-resources) unchanged as they appear to be shared
- Used correct Cloud Deploy syntax: `actualValue # from-param: ${PARAMETER_NAME}`

## Test plan
- [ ] Deploy to dev environment and verify APP_NAME parameter is correctly substituted
- [ ] Check that all resources are created with expected names
- [ ] Verify pod labels and selectors match correctly
- [ ] Test deployment through preview → dev → qa → prod pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)