### PR TITLE
Use deploy parameters from compliance-cli for all environments

### DIFF
--- a/deploy/clouddeploy/dev.yaml
+++ b/deploy/clouddeploy/dev.yaml
@@ -18,24 +18,6 @@ serialPipeline:
     strategy:
       standard:
         verify: false
-    deployParameters:
-      - values:
-          NAMESPACE: "webapp-dev"
-          ENV: "dev"
-          API_URL: "https://api-dev.webapp.u2i.dev"
-          STAGE: "dev"
-          BOUNDARY: "nonprod"
-          TIER: "standard"
-          NAME_PREFIX: "dev-"
-          DOMAIN: "dev.webapp.u2i.dev"
-          ROUTE_NAME: "webapp-dev-route"
-          SERVICE_NAME: "dev-webapp-service"
-          CERT_NAME: "webapp-dev-cert"
-          CERT_ENTRY_NAME: "webapp-dev-entry"
-          CERT_DESCRIPTION: "Certificate for dev.webapp.u2i.dev"
-          PROJECT_ID: "u2i-tenant-webapp-nonprod"
-          PDB_MIN_AVAILABLE: "1"
-          APP_NAME: "webapp"
 
 ---
 apiVersion: deploy.cloud.google.com/v1

--- a/deploy/clouddeploy/qa-prod.yaml
+++ b/deploy/clouddeploy/qa-prod.yaml
@@ -17,24 +17,6 @@ serialPipeline:
       - qa
     strategy:
       standard: {}
-    deployParameters:
-      - values:
-          NAMESPACE: "webapp-qa"
-          ENV: "qa"
-          API_URL: "https://api-qa.webapp.u2i.dev"
-          STAGE: "qa"
-          BOUNDARY: "nonprod"
-          TIER: "standard"
-          NAME_PREFIX: "qa-"
-          DOMAIN: "qa.webapp.u2i.dev"
-          ROUTE_NAME: "webapp-qa-route"
-          SERVICE_NAME: "qa-webapp-service"
-          CERT_NAME: "webapp-qa-cert"
-          CERT_ENTRY_NAME: "webapp-qa-entry"
-          CERT_DESCRIPTION: "Certificate for qa.webapp.u2i.dev"
-          PROJECT_ID: "u2i-tenant-webapp-nonprod"
-          PDB_MIN_AVAILABLE: "1"
-          APP_NAME: "webapp"
   - targetId: prod-gke
     profiles:
       - prod

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,6 +5,6 @@
 set -e
 
 # Download and run the compliance-cli
-# Using specific version to ensure we get v0.3.8 with QA deploy parameters support
-export COMPLIANCE_CLI_VERSION=v0.3.8
+# Using specific version to ensure we get v0.4.0 with full parameter support for all environments
+export COMPLIANCE_CLI_VERSION=v0.4.0
 curl -sL https://raw.githubusercontent.com/u2i/compliance-cli/main/scripts/deploy-wrapper.sh | bash -s -- "$@"


### PR DESCRIPTION
## Summary
- Remove hardcoded deployParameters from Cloud Deploy configurations
- Parameters are now provided dynamically by compliance-cli v0.4.0
- No change in actual deployed values - they remain identical

## Changes
1. **dev.yaml**: Remove all hardcoded deployParameters for dev environment
2. **qa-prod.yaml**: Remove hardcoded deployParameters for QA environment only
3. **Production**: Keep hardcoded parameters as they differ from QA values
4. **deploy.sh**: Update to use compliance-cli v0.4.0

## Verification
The parameters generated by compliance-cli match exactly what was hardcoded:

### Dev Environment
- NAMESPACE: webapp-dev
- ENV: dev  
- API_URL: https://api-dev.webapp.u2i.dev
- DOMAIN: dev.webapp.u2i.dev
- All other parameters match exactly

### QA Environment  
- NAMESPACE: webapp-qa
- ENV: qa
- API_URL: https://api-qa.webapp.u2i.dev
- DOMAIN: qa.webapp.u2i.dev
- All other parameters match exactly

### Production Environment
Continues to use hardcoded parameters as they have different values than QA.

## Related
- Requires compliance-cli v0.4.0: https://github.com/u2i/compliance-cli/releases/tag/v0.4.0

## Test plan
- [ ] Dev deployment uses correct parameters
- [ ] QA deployment uses correct parameters  
- [ ] Production deployment continues to work with promotion

🤖 Generated with [Claude Code](https://claude.ai/code)