### PR TITLE
Fix QA deployment parameter conflicts

### DIFF
--- a/deploy/clouddeploy/qa-prod.yaml
+++ b/deploy/clouddeploy/qa-prod.yaml
@@ -17,6 +17,23 @@ serialPipeline:
       - qa
     strategy:
       standard: {}
+    deployParameters:
+      - values:
+          NAMESPACE: "webapp-qa"
+          ENV: "qa"
+          API_URL: "https://api-qa.webapp.u2i.dev"
+          STAGE: "qa"
+          BOUNDARY: "nonprod"
+          TIER: "standard"
+          NAME_PREFIX: "qa-"
+          DOMAIN: "qa.webapp.u2i.dev"
+          ROUTE_NAME: "webapp-qa-route"
+          SERVICE_NAME: "qa-webapp-service"
+          CERT_NAME: "webapp-qa-cert"
+          CERT_ENTRY_NAME: "webapp-qa-entry"
+          CERT_DESCRIPTION: "Certificate for qa.webapp.u2i.dev"
+          PROJECT_ID: "u2i-tenant-webapp-nonprod"
+          PDB_MIN_AVAILABLE: "1"
   - targetId: prod-gke
     profiles:
       - prod

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,6 +5,6 @@
 set -e
 
 # Download and run the compliance-cli
-# Using specific version to ensure we get v0.4.0 with full parameter support for all environments
-export COMPLIANCE_CLI_VERSION=v0.4.0
+# Using specific version to ensure we get v0.3.8 with QA deploy parameters support
+export COMPLIANCE_CLI_VERSION=v0.3.8
 curl -sL https://raw.githubusercontent.com/u2i/compliance-cli/main/scripts/deploy-wrapper.sh | bash -s -- "$@"


### PR DESCRIPTION
## Summary
Fix QA deployment failure caused by parameter conflicts in multi-stage pipeline.

## Problem
In PR #178, we tried to pass all parameters dynamically for QA, but this caused conflicts because:
- In a multi-stage pipeline (QA->Prod), parameters passed at release creation apply to ALL stages
- QA and Production have different values for parameters like ROUTE_NAME, causing conflicts
- Error: "target prod-gke has two values webapp-route and webapp-qa-route for deploy parameter key ROUTE_NAME"

## Solution
Revert to the original approach:
- Keep QA parameters hardcoded in the pipeline YAML
- Only pass APP_NAME dynamically for QA (via compliance-cli)
- Dev and preview continue to use fully dynamic parameters (single-stage pipelines)

## Changes
- Restore QA deployParameters in qa-prod.yaml
- Revert deploy.sh to use compliance-cli v0.3.8

## Test plan
- [ ] QA deployment succeeds
- [ ] Production promotion works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)