### PR TITLE
Test compliance-cli deployment integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains the WebApp Team's application deployment infrastructure
 
 ## 🏗️ Repository Structure
 
+<!-- Testing compliance-cli deployment integration -->
+
 ```
 webapp-team-app/
 ├── .github/workflows/          # GitOps CI/CD workflows

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ All deployments use the `compliance-cli` tool. For detailed usage:
 #### Deploy to Development
 ```bash
 # Automatic on push to main, or manually:
-./compliance-cli deploy dev
+./compliance-cli dev
 ```
 
 #### Deploy to QA
@@ -146,7 +146,7 @@ gcloud deploy releases promote \
 ```bash
 # Automatic on PR creation/update
 # Manual deployment for testing:
-./compliance-cli deploy preview --pr-number 123
+./compliance-cli preview --pr-number 123
 ```
 
 ## 📋 Compliance Checklist

--- a/compliance-cli
+++ b/compliance-cli
@@ -8,7 +8,7 @@ COMPLIANCE_SOURCE_DIR="../compliance"
 # Check if we should use local source
 if [ -d "$COMPLIANCE_SOURCE_DIR" ] && [ -f "$COMPLIANCE_SOURCE_DIR/go.mod" ]; then
     # Use local source - build and run
-    (cd "$COMPLIANCE_SOURCE_DIR" && go run main.go "$@")
+    (cd "$COMPLIANCE_SOURCE_DIR" && go run cmd/deploy/main.go "$@")
 else
     # Download and run the compliance-cli
     export COMPLIANCE_CLI_VERSION="${COMPLIANCE_CLI_VERSION:-v0.5.0}"

--- a/deploy/cloudbuild/dev.yaml
+++ b/deploy/cloudbuild/dev.yaml
@@ -18,7 +18,7 @@ steps:
 - name: 'google/cloud-sdk:alpine'
   id: 'deploy-dev'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli deploy dev']
+  args: ['-c', './compliance-cli dev']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'

--- a/deploy/cloudbuild/preview.yaml
+++ b/deploy/cloudbuild/preview.yaml
@@ -32,7 +32,7 @@ steps:
 - name: 'google/cloud-sdk:alpine'
   id: 'deploy-preview'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli deploy preview']
+  args: ['-c', './compliance-cli preview']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'

--- a/deploy/cloudbuild/qa.yaml
+++ b/deploy/cloudbuild/qa.yaml
@@ -18,7 +18,7 @@ steps:
 - name: 'google/cloud-sdk:alpine'
   id: 'deploy-qa'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli deploy qa']
+  args: ['-c', './compliance-cli qa']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'


### PR DESCRIPTION
Testing that the new compliance-cli wrapper works correctly with Cloud Build deployments and PR comments.

This PR verifies:
- Preview deployment triggers correctly
- compliance-cli wrapper executes in Cloud Build
- PR comment is posted successfully