### PR TITLE
Fix compliance-cli command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ All deployments use the `compliance-cli` tool. For detailed usage:
 #### Deploy to Development
 ```bash
 # Automatic on push to main, or manually:
-./compliance-cli deploy dev
+./compliance-cli dev
 ```
 
 #### Deploy to QA
@@ -144,7 +144,7 @@ gcloud deploy releases promote \
 ```bash
 # Automatic on PR creation/update
 # Manual deployment for testing:
-./compliance-cli deploy preview --pr-number 123
+./compliance-cli preview --pr-number 123
 ```
 
 ## 📋 Compliance Checklist

--- a/deploy/cloudbuild/dev.yaml
+++ b/deploy/cloudbuild/dev.yaml
@@ -18,7 +18,7 @@ steps:
 - name: 'google/cloud-sdk:alpine'
   id: 'deploy-dev'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli deploy dev']
+  args: ['-c', './compliance-cli dev']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'

--- a/deploy/cloudbuild/preview.yaml
+++ b/deploy/cloudbuild/preview.yaml
@@ -32,7 +32,7 @@ steps:
 - name: 'google/cloud-sdk:alpine'
   id: 'deploy-preview'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli deploy preview']
+  args: ['-c', './compliance-cli preview']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'

--- a/deploy/cloudbuild/qa.yaml
+++ b/deploy/cloudbuild/qa.yaml
@@ -18,7 +18,7 @@ steps:
 - name: 'google/cloud-sdk:alpine'
   id: 'deploy-qa'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli deploy qa']
+  args: ['-c', './compliance-cli qa']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -55,14 +55,14 @@ The WebApp uses Google Cloud Deploy for continuous deployment with the following
 ### Deploy a Preview Environment
 
 ```bash
-./compliance-cli deploy preview --pr-number 123
+./compliance-cli preview --pr-number 123
 # Creates: pr123.webapp.u2i.dev
 ```
 
 ### Promote to Production
 
 ```bash
-./compliance-cli deploy prod --promote --release qa-abc123
+./compliance-cli prod --promote --release qa-abc123
 # Promotes release qa-abc123 from QA to Production (requires approval)
 ```
 

--- a/docs/github-actions-setup.md
+++ b/docs/github-actions-setup.md
@@ -51,7 +51,7 @@ Until WIF is configured, you can test preview deployments manually:
 
 ```bash
 # Deploy a preview
-./compliance-cli deploy preview --pr-number 999
+./compliance-cli preview --pr-number 999
 
 # Check status
 kubectl get pods -n webapp-preview-pr999

--- a/docs/preview-deployments.md
+++ b/docs/preview-deployments.md
@@ -21,7 +21,7 @@ Preview deployments allow you to deploy feature branches or test versions to cus
 
 ```bash
 # Deploy PR preview
-./compliance-cli deploy preview --pr-number 123
+./compliance-cli preview --pr-number 123
 # Creates: pr123.webapp.u2i.dev
 
 # Note: PR number is required for preview deployments

--- a/docs/unified-deploy-script.md
+++ b/docs/unified-deploy-script.md
@@ -5,7 +5,7 @@ This document describes the unified deployment approach using the compliance-cli
 ## Usage
 
 ```bash
-./compliance-cli deploy <environment> [options]
+./compliance-cli <environment> [options]
 ```
 
 ## Environments
@@ -27,28 +27,28 @@ This document describes the unified deployment approach using the compliance-cli
 ### Development Deployment
 ```bash
 # Automatically triggered on merge to main
-./compliance-cli deploy dev
+./compliance-cli dev
 ```
 
 ### Preview Deployment
 ```bash
 # Automatically triggered on PR creation/update
-./compliance-cli deploy preview --pr-number 123
+./compliance-cli preview --pr-number 123
 
 # Or if PR number is in /workspace/pr_number.txt
-./compliance-cli deploy preview
+./compliance-cli preview
 ```
 
 ### QA Deployment
 ```bash
 # Automatically triggered on version tags (v*)
-./compliance-cli deploy qa
+./compliance-cli qa
 ```
 
 ### Production Promotion
 ```bash
 # Manually promote a QA release to production
-./compliance-cli deploy prod --promote --release qa-abc123
+./compliance-cli prod --promote --release qa-abc123
 ```
 
 ## Environment Variables


### PR DESCRIPTION
## Problem
The compliance-cli wrapper was failing with:
```
Error: unknown command "deploy" for "deploy"
```

## Root Cause
The v0.5.0 release binary is actually named `deploy`, not `compliance-cli`. When we call `./compliance-cli deploy preview`, the wrapper downloads a binary named `deploy` and executes it, resulting in `deploy deploy preview` being run.

## Solution
Remove the redundant `deploy` command from all compliance-cli calls:
- `./compliance-cli deploy dev` → `./compliance-cli dev`
- `./compliance-cli deploy qa` → `./compliance-cli qa`
- `./compliance-cli deploy preview` → `./compliance-cli preview`

## Testing
Verified this fix works in test PR #183 - deployment succeeded and PR comment was posted.

## Changes
- Updated all Cloud Build YAML files
- Updated all documentation to reflect correct command syntax