### PR TITLE
Use compliance-cli for PR operations

### DIFF
--- a/deploy/cloudbuild/preview.yaml
+++ b/deploy/cloudbuild/preview.yaml
@@ -5,7 +5,7 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'get-pr-number'
   entrypoint: 'bash'
-  args: ['scripts/get-pr-number.sh']
+  args: ['-c', './compliance-cli pr get-number']
   env:
   - '_PR_NUMBER=${_PR_NUMBER}'
   - '_HEAD_BRANCH=${_HEAD_BRANCH}'


### PR DESCRIPTION
## Summary
Consolidate PR number extraction into the compliance-cli tool.

## Changes
- Replace `scripts/get-pr-number.sh` with `compliance-cli pr get-number`
- The compliance-cli now has PR and Slack commands built-in
- Keeping other scripts temporarily until full implementation is ready

## Testing
The PR deployment for this PR will test the new command.

## Next Steps
- Fully implement PR comment posting in compliance-cli
- Fully implement Slack notifications in compliance-cli
- Remove all obsolete shell scripts once implementations are complete