### PR TITLE
Update to compliance-cli v0.6.0 with PR commands

### DIFF
--- a/compliance-cli
+++ b/compliance-cli
@@ -11,6 +11,6 @@ if [ -d "$COMPLIANCE_SOURCE_DIR" ] && [ -f "$COMPLIANCE_SOURCE_DIR/go.mod" ]; th
     (cd "$COMPLIANCE_SOURCE_DIR" && go run main.go "$@")
 else
     # Download and run the compliance-cli
-    export COMPLIANCE_CLI_VERSION="${COMPLIANCE_CLI_VERSION:-v0.5.0}"
+    export COMPLIANCE_CLI_VERSION="${COMPLIANCE_CLI_VERSION:-v0.6.0}"
     curl -sL https://raw.githubusercontent.com/u2i/compliance-cli/main/scripts/deploy-wrapper.sh | bash -s -- "$@"
 fi

--- a/deploy/cloudbuild/preview.yaml
+++ b/deploy/cloudbuild/preview.yaml
@@ -5,7 +5,7 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'get-pr-number'
   entrypoint: 'bash'
-  args: ['scripts/get-pr-number.sh']
+  args: ['-c', './compliance-cli pr get-number']
   env:
   - '_PR_NUMBER=${_PR_NUMBER}'
   - '_HEAD_BRANCH=${_HEAD_BRANCH}'


### PR DESCRIPTION
## Summary
Update compliance-cli to v0.6.0 which includes built-in PR and Slack commands.

## Changes
- Update compliance-cli wrapper to use v0.6.0
- Replace `scripts/get-pr-number.sh` with `compliance-cli pr get-number`

## Testing
The PR deployment for this PR will test the new v0.6.0 release with PR commands.

## Next Steps
- Implement full PR comment posting in compliance-cli
- Implement full Slack notifications in compliance-cli  
- Remove all obsolete shell scripts