### PR TITLE
test: Preview cleanup with pre-built compliance-cli image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # Makefile for webapp-team-app
 
-# Use the compliance-cli wrapper in root
-COMPLIANCE_CLI = ./compliance-cli
+# Use the dockerized compliance-cli
+COMPLIANCE_CLI_IMAGE = us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest
+COMPLIANCE_CLI = docker run --rm -v $(PWD):/workspace -w /workspace $(COMPLIANCE_CLI_IMAGE) compliance-cli
 
 .PHONY: generate-pipelines
 generate-pipelines:

--- a/deploy/cloudbuild/dev.yaml
+++ b/deploy/cloudbuild/dev.yaml
@@ -14,22 +14,22 @@ steps:
   id: 'push-image'
   args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp']
 
-# Deploy using Cloud Deploy
-- name: 'google/cloud-sdk:alpine'
+# Deploy using Cloud Deploy with pre-built compliance-cli image
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'deploy-dev'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli dev']
+  args: ['-c', 'compliance-cli dev']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'
   - 'COMMIT_SHA=$COMMIT_SHA'
   - 'SHORT_SHA=$SHORT_SHA'
 
-# Send Slack notification
-- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
+# Send Slack notification using pre-built compliance-cli image
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'slack-notification'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli slack notify --environment dev']
+  args: ['-c', 'compliance-cli slack notify --environment dev']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'

--- a/deploy/cloudbuild/preview-cleanup.yaml
+++ b/deploy/cloudbuild/preview-cleanup.yaml
@@ -2,15 +2,15 @@
 # This should be triggered on a schedule (e.g., daily)
 
 steps:
-# Run preview cleanup
-- name: 'google/cloud-sdk:alpine'
+# Run preview cleanup using pre-built compliance-cli image
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'cleanup-previews'
   entrypoint: 'bash'
   args: 
   - '-c'
   - |
     echo "🧹 Cleaning up preview environments older than ${_DAYS_OLD} days"
-    ./compliance-cli preview cleanup --days-old=${_DAYS_OLD}
+    compliance-cli preview cleanup --days-old=${_DAYS_OLD}
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'

--- a/deploy/cloudbuild/preview-destroy.yaml
+++ b/deploy/cloudbuild/preview-destroy.yaml
@@ -36,8 +36,8 @@ steps:
     echo "PR #$PR_NUMBER is closed, proceeding with cleanup..."
     echo "$PR_NUMBER" > /workspace/pr_number.txt
 
-# Destroy the preview environment (only if PR is closed)
-- name: 'google/cloud-sdk:alpine'
+# Destroy the preview environment using pre-built compliance-cli image
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'destroy-preview'
   entrypoint: 'bash'
   args: 
@@ -51,12 +51,8 @@ steps:
     PR_NUMBER=$(cat /workspace/pr_number.txt)
     echo "🧹 Destroying preview environment for PR #${PR_NUMBER}"
     
-    # Download and run compliance-cli
-    apk add --no-cache curl
-    ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
-    curl -sSL -o /workspace/compliance-cli "https://github.com/u2i/compliance-cli/releases/latest/download/compliance-cli-linux-${ARCH}"
-    chmod +x /workspace/compliance-cli
-    /workspace/compliance-cli preview destroy --pr=${PR_NUMBER}
+    # compliance-cli is pre-installed in this image
+    compliance-cli preview destroy --pr=${PR_NUMBER}
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'

--- a/deploy/cloudbuild/preview.yaml
+++ b/deploy/cloudbuild/preview.yaml
@@ -1,11 +1,11 @@
 # No secrets needed here - GitHub App auth handled in script
 
 steps:
-# Extract PR number from the pull request
-- name: 'gcr.io/cloud-builders/gcloud'
+# Extract PR number from the pull request using pre-built compliance-cli image
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'get-pr-number'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli pr get-number']
+  args: ['-c', 'compliance-cli pr get-number']
   env:
   - '_PR_NUMBER=${_PR_NUMBER}'
   - '_HEAD_BRANCH=${_HEAD_BRANCH}'
@@ -28,22 +28,22 @@ steps:
   id: 'push-image'
   args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp']
 
-# Deploy using Cloud Deploy
-- name: 'google/cloud-sdk:alpine'
+# Deploy using Cloud Deploy with pre-built compliance-cli image
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'deploy-preview'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli preview']
+  args: ['-c', 'compliance-cli preview']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'
   - 'COMMIT_SHA=$COMMIT_SHA'
   - 'SHORT_SHA=$SHORT_SHA'
 
-# Post comment on PR using GitHub App
-- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
+# Post comment on PR using pre-built compliance-cli image
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'post-comment'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli pr comment']
+  args: ['-c', 'compliance-cli pr comment']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'

--- a/deploy/cloudbuild/qa.yaml
+++ b/deploy/cloudbuild/qa.yaml
@@ -14,11 +14,11 @@ steps:
   id: 'push-image'
   args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp']
 
-# Deploy using Cloud Deploy
-- name: 'google/cloud-sdk:alpine'
+# Deploy using Cloud Deploy with pre-built compliance-cli image
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'deploy-qa'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli qa']
+  args: ['-c', 'compliance-cli qa']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'
@@ -26,11 +26,11 @@ steps:
   - 'SHORT_SHA=$SHORT_SHA'
   - 'TAG_NAME=$TAG_NAME'
 
-# Send Slack notification
-- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
+# Send Slack notification using pre-built compliance-cli image
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'slack-notification'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli slack notify --environment qa']
+  args: ['-c', 'compliance-cli slack notify --environment qa']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'


### PR DESCRIPTION
## Summary
- Updated all CloudBuild configurations to use pre-built compliance-cli image
- Updated Makefile to use dockerized compliance-cli
- This PR tests the preview cleanup functionality with the new image

## Changes
- Uses `us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest` 
- No longer needs to download compliance-cli or use wrapper scripts
- Makefile now runs compliance-cli via Docker
- Should improve build performance and reliability

## Test Plan
1. This PR will trigger a preview deployment using the new image
2. After merge/close, preview-destroy will clean up using the new image
3. Scheduled cleanup (preview-cleanup.yaml) also updated to use new image