### PR TITLE
test: Verify domain-wide permissions

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ app.get('/ready', (req, res) => {
 
 app.get('/', (req, res) => {
   res.json({
-    message: 'Hello from webapp! v7.2 - Full pipeline test',
+    message: 'Hello from webapp! v7.3 - Testing domain-wide permissions',
     boundary: boundary,
     stage: stage,
     version: version,

--- a/deploy/cloudbuild/preview.yaml
+++ b/deploy/cloudbuild/preview.yaml
@@ -1,11 +1,11 @@
 # No secrets needed here - GitHub App auth handled in script
 
 steps:
-# Extract PR number from the pull request
-- name: 'gcr.io/cloud-builders/gcloud'
+# Extract PR number from the pull request using pre-built compliance-cli image
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'get-pr-number'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli pr get-number']
+  args: ['-c', 'compliance-cli pr get-number']
   env:
   - '_PR_NUMBER=${_PR_NUMBER}'
   - '_HEAD_BRANCH=${_HEAD_BRANCH}'
@@ -28,22 +28,22 @@ steps:
   id: 'push-image'
   args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp']
 
-# Deploy using Cloud Deploy
-- name: 'google/cloud-sdk:alpine'
+# Deploy using Cloud Deploy with pre-built compliance-cli image
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'deploy-preview'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli preview']
+  args: ['-c', 'compliance-cli preview']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'
   - 'COMMIT_SHA=$COMMIT_SHA'
   - 'SHORT_SHA=$SHORT_SHA'
 
-# Post comment on PR using GitHub App
-- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
+# Post comment on PR using pre-built compliance-cli image
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'post-comment'
   entrypoint: 'bash'
-  args: ['-c', './compliance-cli pr comment']
+  args: ['-c', 'compliance-cli pr comment']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'


### PR DESCRIPTION
## Summary
Testing that the new domain-wide permissions (domain:u2i.com) work correctly for pulling the compliance-cli image.

## Context
Bootstrap image access has been simplified:
- Replaced individual service account permissions with domain-wide access
- Any service account in u2i.com can now pull from bootstrap repositories
- This should work automatically without specific service account grants

## Test
This PR verifies:
- Preview deployment can pull compliance-cli-builder image
- No permission errors with the simplified access model
- Build completes successfully with pre-built image