### PR TITLE
fix: Preview deploy command and test cert provisioning

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ app.get('/ready', (req, res) => {
 
 app.get('/', (req, res) => {
   res.json({
-    message: 'Hello from webapp! v7.2 - Full pipeline test',
+    message: 'Hello from webapp! v7.5 - Testing preview with cert provisioning',
     boundary: boundary,
     stage: stage,
     version: version,

--- a/deploy/cloudbuild/preview.yaml
+++ b/deploy/cloudbuild/preview.yaml
@@ -32,7 +32,7 @@ steps:
 - name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'deploy-preview'
   entrypoint: 'bash'
-  args: ['-c', 'compliance-cli preview']
+  args: ['-c', 'compliance-cli preview deploy']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'

--- a/deploy/skaffold.yaml
+++ b/deploy/skaffold.yaml
@@ -38,7 +38,7 @@ profiles:
       flags:
         apply: ["--server-side", "--force-conflicts"]
     statusCheck: true
-    statusCheckDeadlineSeconds: 300
+    statusCheckDeadlineSeconds: 600
     tolerateFailuresUntilDeadline: true
 
 # Dev profile - includes namespace creation


### PR DESCRIPTION
## Summary
Fixing the preview deployment command and testing certificate provisioning with proper wait time.

## Changes
- Fixed command: `compliance-cli preview` → `compliance-cli preview deploy`
- Version bump to v7.5 for tracking

## Test Plan
1. PR will trigger preview deployment
2. Will wait for certificate provisioning (up to 10 minutes)
3. Will verify the preview is accessible via curl

## Note
This test will properly wait for certificate provisioning to complete before checking accessibility.