### PR TITLE
feat: Update to modern Artifact Registry URL

### DIFF
--- a/bin/compliance-cli
+++ b/bin/compliance-cli
@@ -8,5 +8,5 @@ exec docker run --rm \
     -v "${HOME}/.config/gcloud:/root/.config/gcloud" \
     -e "PROJECT_ID=${PROJECT_ID:-u2i-tenant-webapp-nonprod}" \
     -e "REGION=${REGION:-europe-west1}" \
-    gcr.io/u2i-bootstrap/compliance-cli-builder:latest \
+    us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest \
     -c "compliance-cli $*"

--- a/deploy/cloudbuild/dev.yaml
+++ b/deploy/cloudbuild/dev.yaml
@@ -15,7 +15,7 @@ steps:
   args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp']
 
 # Deploy using compliance-cli
-- name: 'gcr.io/u2i-bootstrap/compliance-cli-builder:latest'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'deploy-dev'
   entrypoint: 'compliance-cli'
   args: ['dev']
@@ -26,7 +26,7 @@ steps:
   - 'SHORT_SHA=$SHORT_SHA'
 
 # Send Slack notification
-- name: 'gcr.io/u2i-bootstrap/compliance-cli-builder:latest'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'slack-notification'
   entrypoint: 'compliance-cli'
   args: ['slack', 'notify', '--environment', 'dev']

--- a/deploy/cloudbuild/preview-cleanup.yaml
+++ b/deploy/cloudbuild/preview-cleanup.yaml
@@ -3,7 +3,7 @@
 
 steps:
 # Run preview cleanup
-- name: 'gcr.io/u2i-bootstrap/compliance-cli-builder:latest'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'cleanup-previews'
   entrypoint: 'bash'
   args: 

--- a/deploy/cloudbuild/preview-destroy.yaml
+++ b/deploy/cloudbuild/preview-destroy.yaml
@@ -37,7 +37,7 @@ steps:
     echo "$PR_NUMBER" > /workspace/pr_number.txt
 
 # Destroy the preview environment
-- name: 'gcr.io/u2i-bootstrap/compliance-cli-builder:latest'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'destroy-preview'
   entrypoint: 'bash'
   args: 

--- a/deploy/cloudbuild/preview.yaml
+++ b/deploy/cloudbuild/preview.yaml
@@ -2,7 +2,7 @@
 
 steps:
 # Extract PR number from the pull request
-- name: 'gcr.io/u2i-bootstrap/compliance-cli-builder:latest'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'get-pr-number'
   entrypoint: 'compliance-cli'
   args: ['pr', 'get-number']
@@ -29,7 +29,7 @@ steps:
   args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp']
 
 # Deploy using compliance-cli
-- name: 'gcr.io/u2i-bootstrap/compliance-cli-builder:latest'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'deploy-preview'
   entrypoint: 'compliance-cli'
   args: ['preview', 'deploy']
@@ -40,7 +40,7 @@ steps:
   - 'SHORT_SHA=$SHORT_SHA'
 
 # Post comment on PR
-- name: 'gcr.io/u2i-bootstrap/compliance-cli-builder:latest'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'post-comment'
   entrypoint: 'compliance-cli'
   args: ['pr', 'comment']

--- a/deploy/cloudbuild/qa.yaml
+++ b/deploy/cloudbuild/qa.yaml
@@ -15,7 +15,7 @@ steps:
   args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp']
 
 # Deploy to QA using compliance-cli
-- name: 'gcr.io/u2i-bootstrap/compliance-cli-builder:latest'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'deploy-qa'
   entrypoint: 'compliance-cli'
   args: ['qa']
@@ -26,7 +26,7 @@ steps:
   - 'SHORT_SHA=$SHORT_SHA'
 
 # Send Slack notification
-- name: 'gcr.io/u2i-bootstrap/compliance-cli-builder:latest'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'slack-notification'
   entrypoint: 'compliance-cli'
   args: ['slack', 'notify', '--environment', 'qa']


### PR DESCRIPTION
## Summary
- Updates all compliance-cli Docker image references from legacy gcr.io to modern Artifact Registry URL
- Changes from `gcr.io/u2i-bootstrap/compliance-cli-builder:latest` to `us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest`
- Follows GCP best practices for container image hosting

## Changes
- All Cloud Build configs (dev, qa, preview, preview-destroy, preview-cleanup)
- Local wrapper script (bin/compliance-cli)

## Testing
This PR will trigger a preview deployment to verify the new image URL works correctly.