### PR TITLE
test: Verify PR number fix for preview deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,7 @@ Before each deployment, ensure:
 - **Security Issues**: security-team@u2i.com  
 - **Platform Support**: platform-team@u2i.com
 - **Compliance Questions**: compliance@u2i.com
+
+## Testing PR Number Fix
+Timestamp: 20250902-201337
+Testing that preview deployments now correctly use the PR number from the trigger.

--- a/deploy/cloudbuild/preview.yaml
+++ b/deploy/cloudbuild/preview.yaml
@@ -18,7 +18,7 @@ steps:
 - name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:latest'
   id: 'deploy-preview'
   entrypoint: 'compliance-cli'
-  args: ['preview', 'deploy']
+  args: ['preview', 'deploy', '--pr-number', '${_PR_NUMBER}']
   env:
   - 'PROJECT_ID=${_PROJECT_ID}'
   - 'REGION=${_REGION}'

--- a/deploy/cloudbuild/preview.yaml
+++ b/deploy/cloudbuild/preview.yaml
@@ -4,8 +4,8 @@ steps:
   id: 'build-image'
   args: [
     'build',
-    '-t', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp:preview-${_PR_NUMBER}-${COMMIT_SHA}',
-    '-t', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp:preview-${_PR_NUMBER}-latest',
+    '-t', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp:preview-${COMMIT_SHA}',
+    '-t', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp:preview-pr${_PR_NUMBER}-latest',
     '.'
   ]
 


### PR DESCRIPTION
Testing that the updated Cloud Build trigger now correctly passes the PR number to preview deployments.

Expected outcome:
- Preview should deploy to `preview-pr<NUMBER>` namespace (not `preview-pr1`)
- The PR number should be correctly extracted from the GitHub event
- Preview URL should be `https://preview-pr<NUMBER>.webapp.u2i.dev`