### PR TITLE
test: Verify v0.9.2 parameter substitution

### DIFF
--- a/test-secrets.md
+++ b/test-secrets.md
@@ -12,4 +12,4 @@ This PR tests the fix for External Secrets in preview environments.
 - Parameters now properly passed during deployment
 
 ## Verification
-Check the ExternalSecret and SecretStore status after deployment.
+Check the ExternalSecret and SecretStore status after deployment.Testing v0.9.2 with parameter substitution


### PR DESCRIPTION
Testing that compliance-cli v0.9.2 properly substitutes CLUSTER_LOCATION and CLUSTER_NAME parameters.

This should fix External Secrets authentication without hardcoded values.