### PR TITLE
fix: Update compliance-cli image to Artifact Registry location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # Get the compliance-cli version from config
 COMPLIANCE_CLI_VERSION := $(shell grep compliance_cli_version .compliance-cli.yml | cut -d: -f2 | tr -d ' ')
-COMPLIANCE_CLI_IMAGE := gcr.io/u2i-bootstrap/compliance-cli:$(COMPLIANCE_CLI_VERSION)
+COMPLIANCE_CLI_IMAGE := us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:$(COMPLIANCE_CLI_VERSION)
 
 # Docker run command with current directory mounted
 DOCKER_RUN := docker run --rm -v $(PWD):/workspace -w /workspace $(COMPLIANCE_CLI_IMAGE) compliance-cli

--- a/deploy/cloudbuild/dev.yaml
+++ b/deploy/cloudbuild/dev.yaml
@@ -68,7 +68,7 @@ steps:
   args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp']
 
 # Deploy using compliance-cli
-- name: 'gcr.io/u2i-bootstrap/compliance-cli:v0.11.1'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:v0.11.1'
   id: 'deploy-dev'
   entrypoint: 'compliance-cli'
   args: ['dev']
@@ -79,7 +79,7 @@ steps:
   - 'SHORT_SHA=$SHORT_SHA'
 
 # Send Slack notification
-- name: 'gcr.io/u2i-bootstrap/compliance-cli:v0.11.1'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:v0.11.1'
   id: 'slack-notification'
   entrypoint: 'compliance-cli'
   args: ['slack', 'notify', '--environment', 'dev']

--- a/deploy/cloudbuild/preview-cleanup.yaml
+++ b/deploy/cloudbuild/preview-cleanup.yaml
@@ -5,7 +5,7 @@
 
 steps:
 # Clean up preview environments using compliance-cli
-- name: 'gcr.io/u2i-bootstrap/compliance-cli:v0.11.1'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:v0.11.1'
   id: 'cleanup-previews'
   entrypoint: 'compliance-cli'
   args: ['preview', 'cleanup']

--- a/deploy/cloudbuild/preview-destroy.yaml
+++ b/deploy/cloudbuild/preview-destroy.yaml
@@ -5,7 +5,7 @@
 
 steps:
 # Destroy preview environment using compliance-cli
-- name: 'gcr.io/u2i-bootstrap/compliance-cli:v0.11.1'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:v0.11.1'
   id: 'destroy-preview'
   entrypoint: 'compliance-cli'
   args: ['preview', 'destroy']

--- a/deploy/cloudbuild/preview.yaml
+++ b/deploy/cloudbuild/preview.yaml
@@ -68,7 +68,7 @@ steps:
   args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp']
 
 # Deploy preview environment using compliance-cli
-- name: 'gcr.io/u2i-bootstrap/compliance-cli:v0.11.1'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:v0.11.1'
   id: 'deploy-preview'
   entrypoint: 'compliance-cli'
   args: ['preview', 'deploy', '--pr-number', '${_PR_NUMBER}']
@@ -80,7 +80,7 @@ steps:
   - 'PR_NUMBER=${_PR_NUMBER}'
 
 # Post PR comment with preview URL
-- name: 'gcr.io/u2i-bootstrap/compliance-cli:v0.11.1'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:v0.11.1'
   id: 'post-pr-comment'
   entrypoint: 'compliance-cli'
   args: ['pr', 'comment', '--pr-number', '${_PR_NUMBER}']

--- a/deploy/cloudbuild/qa.yaml
+++ b/deploy/cloudbuild/qa.yaml
@@ -69,7 +69,7 @@ steps:
   args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/webapp-images/webapp']
 
 # Deploy using compliance-cli
-- name: 'gcr.io/u2i-bootstrap/compliance-cli:v0.11.1'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:v0.11.1'
   id: 'deploy-qa'
   entrypoint: 'compliance-cli'
   args: ['qa']
@@ -81,7 +81,7 @@ steps:
   - 'TAG_NAME=$TAG_NAME'
 
 # Send Slack notification
-- name: 'gcr.io/u2i-bootstrap/compliance-cli:v0.11.1'
+- name: 'us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder:v0.11.1'
   id: 'slack-notification'
   entrypoint: 'compliance-cli'
   args: ['slack', 'notify', '--environment', 'qa']

--- a/deploy/clouddeploy/dev.yml
+++ b/deploy/clouddeploy/dev.yml
@@ -5,7 +5,7 @@
 # To make changes, edit the template at:
 # compliance-cli/internal/generate/templates/pipelines/dev.yaml.tmpl
 # 
-# Generated on: 2025-09-15 21:44:59 UTC
+# Generated on: 2025-09-17 16:51:28 UTC
 # To regenerate: make generate-pipelines
 # ===========================================================================
 

--- a/deploy/clouddeploy/preview.yml
+++ b/deploy/clouddeploy/preview.yml
@@ -5,7 +5,7 @@
 # To make changes, edit the template at:
 # compliance-cli/internal/generate/templates/pipelines/preview.yaml.tmpl
 # 
-# Generated on: 2025-09-15 21:44:59 UTC
+# Generated on: 2025-09-17 16:51:28 UTC
 # To regenerate: make generate-pipelines
 # ===========================================================================
 

--- a/deploy/clouddeploy/qa-prod.yml
+++ b/deploy/clouddeploy/qa-prod.yml
@@ -5,7 +5,7 @@
 # To make changes, edit the template at:
 # compliance-cli/internal/generate/templates/pipelines/qa-prod.yaml.tmpl
 # 
-# Generated on: 2025-09-15 21:44:59 UTC
+# Generated on: 2025-09-17 16:51:28 UTC
 # To regenerate: make generate-pipelines
 # ===========================================================================
 


### PR DESCRIPTION
## Summary
- Migrate compliance-cli Docker image from Container Registry (gcr.io) to Artifact Registry (us-docker.pkg.dev)
- Update Makefile to use new image location consistently
- Regenerate all deployment configurations with updated image references

## Changes
- Updated COMPLIANCE_CLI_IMAGE in Makefile from `gcr.io/u2i-bootstrap/compliance-cli` to `us-docker.pkg.dev/u2i-bootstrap/gcr.io/compliance-cli-builder`
- Regenerated all Cloud Build and Cloud Deploy files with consistent image references
- Only substantive change is the Docker registry location; timestamps also updated

## Testing
- Run `make generate` to verify idempotent behavior (only timestamps should change)
- PR preview deployment will validate the new image location works correctly
- All environments will use the same consistent image location

## Impact
This ensures compatibility with the latest infrastructure changes where images have been migrated to Artifact Registry.